### PR TITLE
Phase1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Package name and even org name can still be changed at this time. Suggestions we
 Installation
 ------
 
-Not implemented yet. This is an illustration of desired installation.
+Not implemented yet. This is an illustration of desired installation. This section should be updated when
+we release v1
 
 
 For dotnet app you can install and use like this:
@@ -44,8 +45,9 @@ This approach needs some investigation
 Usage
 -------
 
-The following is just some psuedocode. Note, we'll need a resource manager and resource files (work already begun) 
-to provide translations for enums (even for English). 
+The following is just some pseudocode. Note, we'll need a resource manager and resource files (work already begun) 
+to provide translations for enums (even for English). This section should be updated with real examples when
+we release v1
 
 ```csharp
 // Login
@@ -77,11 +79,11 @@ Console.Log(result.BooleanValue) // prints "True" or "False". This BooleanValue 
 
 // Read an array value, new for basic services, didn't exist in MSSDA
 var result = client.ReadProperty(guid5, "ipAddress") // ipAddress is an array of bytes
-var firstByteResult = result.ArrayValue
+var firstByteResult = result.ArrayValue[0]
 Console.Log(firstByteResult.Item1)   // prints "192" as Item1 is the string representation
 
 // alternatively
-var (string StringValue, double NumericValue) result = client.ReadProperty(guid5, "ipAddress") // ipAddress is an array of bytes
+var (string StringValue, double NumericValue) secondByte = result.ArrayValue[1] 
 Console.Log(result.StringValue)
 
 ```
@@ -90,11 +92,15 @@ Console.Log(result.StringValue)
 Requirements
 -----------
 
-This project will have several small phases. The first phase will
-expose add reading of objects/attributes. The second phase will writing and commanding.
-The final phase will add discover of devices and objects.
+This section should be moved into a seperate Requirements document. Or we can create cards in the 
+associated [project](https://github.com/metasys-server/basic-services-dotnet/projects/1) to track
+work/requirements. Or we can use Issues. Once development begins in earnest lets clean this up.
 
-* The project must maintain a CHANGELOG (https://keepachangelog.com/en/1.0.0/).I have example here: https://github.com/metasys-server/nodekit/blob/master/CHANGELOG.md 
+This project will have several small phases. The first phase will
+expose add reading of objects/attributes. The second phase will add writing and commanding.
+The final phase will add discovery of devices and objects.
+
+* The project must maintain a CHANGELOG (https://keepachangelog.com/en/1.0.0/ ).I have example here: https://github.com/metasys-server/nodekit/blob/master/CHANGELOG.md 
 * This package must be published in the metasys organization at nuget.org with appropriate semantic versioning, https://semver.org
 copyright, licensing, link to github repo, etc. 
 
@@ -114,6 +120,22 @@ Only the smallest of commits should be one line messages.
 * Consider adding a light weight CONTRIBUTING.md or referencing Microsoft's for guidance for outsiders and others in JCI.
 
 * Track the Issues on this repo and provide guidance (where possible) on roadmap.
+
+* We should consider the suitability of signing our dll. See this tutorial on how one might mark their dlls as
+  truste in the nuget repository. https://natemcmaster.com/blog/2018/07/02/code-signing/ 
+  
+* Every published release should be tagged with a signed tag. So if there is a v1 in nuget.org then the releases tab
+  and the tags tab of this repo should have a v1 as well.
+  
+* We want our customers to get documentation of our library while using intellisense in their IDE. Follow Microsoft
+  guidelines for writing XML Comments and making them available in nuget package for clients. Here's a stackoverflow
+  Q&A that says how to do it. https://stackoverflow.com/questions/19672943/xml-comments-in-nuget-package 
+  
+* Need CI pipeline. Once a PR is create the automated tests run. Nice to have an publish process as well so that
+  once we decide we want to publish a version it's easy to do. Perhaps a simple script. Consider an OAS in Azure that
+  we can snapshot to reset back to known state before tests run.
+  
+* Add appropriate badges to README (for example last build successful) 
 
 ### Phase 1
 
@@ -138,7 +160,9 @@ The following requirements will be met in phase 1:
 1. Implement ReadProperty
 2. Implement ReadPropertyMultiple
 3. Expose the library as COM dll for use in Excel apps
-4. Ensure signatures of the methods are easy to consume via COM
+4. Ensure signatures of the methods are easy to consume via COM (Using exceptions is probably a bad idea.
+   If we find exceptions are the best for .Net consumers then we'll want separate methods exposed for Excel
+   that return error codes rather than throw exceptions)
 5. Must provide client side resource files for translating enum values
    coming back from the server. (Unlike MSSDA, enums are not returned
    from the server as localized strings. They are returned as "symbolic
@@ -147,6 +171,7 @@ The following requirements will be met in phase 1:
    strings.
 6. Nuget package support (for deployment to metasys-server org)
 7. Script for registering dll for COM (would only be used by Excel apps, wouldn't be needed for .Net apps)
+8. Script for unregistering dll
 
 Suppoted Data Types
 
@@ -168,9 +193,9 @@ find the enum value associated (for usage in SendCommand and WriteProperty)
 ### Phase 3
 
 1. Implement GetObjectList() this will differ from MSSDA. MSSDA returned just the immediate children of given object.
-   10.1 Metasys Server has the /objects endpoint which allows you to specify a parent object and ask for children `/objects/{id}/objects`
-   but it'll return all children. And the result will be paged. So we can decide if GetObjectList should fetch all pages.
-   Probably it should. (Future release we could add support for paging in client)
+   10.1 Metasys Server has the /objects endpoint which doesn't allow you to specify a depth parameter. It returns all children
+   but the result is paged. So we can decide if GetObjectList should fetch all pages or if we should add paging support to
+   this method. First release should probably just use a large page size and loop until all children have been processed.
    
 2. Implement GetDeviceList() this will likely differ from MSSDA as well. We have the /networkDevices endpoint which will
    be the source of data. 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# basic-services-dotnet
-A simple client for access the most common services of the Metasys API (in the style of the old MSSDA)

--- a/basic-services.DotSettings
+++ b/basic-services.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Metasys/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Net.Http;
+using Flurl.Http.Testing;
+using NUnit.Framework;
+using JohnsonControls.Metasys.BasicServices;
+
+namespace Tests
+{
+    public class TraditionalClientTests
+    {
+        TraditionalClient traditionalClient;
+
+        // [SetUp]
+        // public void Setup()
+        // {
+        //     //traditionalClient = new TraditionalClient();
+        // }
+
+        [Test]
+        public void TestLogin()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2020-01-01T00:00:00Z"});
+                traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/login")
+                    .WithVerb(HttpMethod.Post)
+                    .WithContentType("application/json")
+                    .WithRequestBody("{\"username\":\"username\",\"password\":\"password\"")
+                    .Times(1);
+            }
+        }
+
+        [Test]
+        public void TestRefresh()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2020-01-01T00:00:00Z"});
+                traditionalClient.Refresh();
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/refreshToken")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+            }
+        }
+    }
+}

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -7,17 +7,18 @@ using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 using JohnsonControls.Metasys.BasicServices;
 
-
 namespace Tests
 {
     public class TraditionalClientTests
     {
         Guid mockid;
         string mockAttributeName;
+        TraditionalClient traditionalClient;
 
         [SetUp]
         public void Init()
         {
+            traditionalClient = new TraditionalClient();
             mockAttributeName = "property";
             mockid = new Guid("11111111-2222-3333-4444-555555555555");
         }
@@ -28,8 +29,8 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/login")
+                traditionalClient.TryLogin("username", "password", "hostname");
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/login")
                     .WithVerb(HttpMethod.Post)
                     .WithContentType("application/json")
                     .WithRequestBody("{\"username\":\"username\",\"password\":\"password\"")
@@ -44,10 +45,10 @@ namespace Tests
             {
                 httpTest.RespondWith("unauthorized", 401);
                 try {
-                    var traditionalClient = new TraditionalClient("username", "badpassword", "hostname", 2);
+                    traditionalClient.TryLogin("username", "badpassword", "hostname");
                     Assert.Fail();
                 } catch {
-                    httpTest.ShouldHaveCalled($"https://hostname/api/v2/login")
+                    httpTest.ShouldHaveCalled($"https://hostname/api/V2/login")
                     .WithVerb(HttpMethod.Post)
                     .WithContentType("application/json")
                     .WithRequestBody("{\"username\":\"username\",\"password\":\"badpassword\"")
@@ -61,12 +62,12 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWith("Call failed. No such host is known POST https://badhost/api/v2/login");
+                httpTest.RespondWith("Call failed. No such host is known POST https://badhost/api/V2/login");
                 try {
-                    var traditionalClient = new TraditionalClient("username", "password", "badhost", 2);
+                    traditionalClient.TryLogin("username", "password", "badhost");
                     Assert.Fail();
                 } catch {
-                    httpTest.ShouldHaveCalled($"https://badhost/api/v2/login")
+                    httpTest.ShouldHaveCalled($"https://badhost/api/V2/login")
                     .WithVerb(HttpMethod.Post)
                     .WithContentType("application/json")
                     .WithRequestBody("{\"username\":\"username\",\"password\":\"password\"")
@@ -75,20 +76,20 @@ namespace Tests
             }
         }
 
-        [Test]
-        public void TestBadVersionLogin()
-        {
-            using (var httpTest = new HttpTest())
-            {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 1);
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/login")
-                    .WithVerb(HttpMethod.Post)
-                    .WithContentType("application/json")
-                    .WithRequestBody("{\"username\":\"username\",\"password\":\"password\"")
-                    .Times(1);
-            }
-        }
+        // [Test]
+        // public void TestBadVersionLogin()
+        // {
+        //     using (var httpTest = new HttpTest())
+        //     {
+        //         httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+        //         traditionalClient.TryLogin("username", "password", "hostname");
+        //         httpTest.ShouldHaveCalled($"https://hostname/api/V2/login")
+        //             .WithVerb(HttpMethod.Post)
+        //             .WithContentType("application/json")
+        //             .WithRequestBody("{\"username\":\"username\",\"password\":\"password\"")
+        //             .Times(1);
+        //     }
+        // }
 
         [Test]
         public void TestRefresh()
@@ -96,11 +97,11 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
                 traditionalClient.Refresh();
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/refreshToken")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/refreshToken")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
             }
@@ -112,14 +113,14 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("unauthorized", 401);
                 try {
                     traditionalClient.Refresh();
                     Assert.Fail();
                 } catch {
-                    httpTest.ShouldHaveCalled($"https://hostname/api/v2/refreshToken")
+                    httpTest.ShouldHaveCalled($"https://hostname/api/V2/refreshToken")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 }
@@ -132,14 +133,14 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(mockid.ToString());
                 var id = traditionalClient.GetObjectIdentifier("fully:qualified/reference");
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objectIdentifiers")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objectIdentifiers")
                 .WithVerb(HttpMethod.Get)
                 .Times(1);
-                Assert.AreEqual(id.GetType(), typeof(Guid));
+                Assert.AreEqual(typeof(Guid), id.GetType());
             }
         }
 
@@ -149,14 +150,14 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Bad Request", 400);
                 try {
                     var id = traditionalClient.GetObjectIdentifier("fully:qualified/reference");
                     Assert.Fail();
                 } catch {
-                    httpTest.ShouldHaveCalled($"https://hostname/api/v2/objectIdentifiers")
+                    httpTest.ShouldHaveCalled($"https://hostname/api/V2/objectIdentifiers")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 }
@@ -169,20 +170,20 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": 1 }}");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 1);
-                Assert.AreEqual(result.StringValue, "1");
-                Assert.AreEqual(result.ArrayValue, null);
-                Assert.AreEqual(result.Priority, null);
-                Assert.AreEqual(result.Reliability, null);
-                Assert.AreEqual(result.IsReliable, false);
+                Assert.AreEqual(1, result.NumericValue);
+                Assert.AreEqual("1", result.StringValue);
+                Assert.AreEqual(null, result.ArrayValue);
+                Assert.AreEqual(null, result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -192,20 +193,20 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": 1.1 }}");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 1.1);
-                Assert.AreEqual(result.StringValue, "1.1");
-                Assert.AreEqual(result.ArrayValue, null);
-                Assert.AreEqual(result.Priority, null);
-                Assert.AreEqual(result.Reliability, null);
-                Assert.AreEqual(result.IsReliable, false);
+                Assert.AreEqual(1.1, result.NumericValue);
+                Assert.AreEqual("1.1", result.StringValue);
+                Assert.AreEqual(null, result.ArrayValue);
+                Assert.AreEqual(null, result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -215,20 +216,20 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": \"stringvalue\" }}");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
-                    .Times(1);
-                Assert.AreEqual(result.NumericValue, 0);
-                Assert.AreEqual(result.StringValue, "stringvalue");
-                Assert.AreEqual(result.ArrayValue, null);
-                Assert.AreEqual(result.Priority, null);
-                Assert.AreEqual(result.Reliability, null);
-                Assert.AreEqual(result.IsReliable, false);
+                    .Times(1);                
+                Assert.AreEqual(0, result.NumericValue);
+                Assert.AreEqual("stringvalue", result.StringValue);
+                Assert.AreEqual(null, result.ArrayValue);
+                Assert.AreEqual(null, result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -238,20 +239,20 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": true }}");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 1);
-                Assert.AreEqual(result.StringValue, "True");
-                Assert.AreEqual(result.ArrayValue, null);
-                Assert.AreEqual(result.Priority, null);
-                Assert.AreEqual(result.Reliability, null);
-                Assert.AreEqual(result.IsReliable, false);
+                Assert.AreEqual(1, result.NumericValue);
+                Assert.AreEqual("True", result.StringValue);
+                Assert.AreEqual(null, result.ArrayValue);                
+                Assert.AreEqual(null, result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -261,20 +262,20 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": false }}");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 0);
-                Assert.AreEqual(result.StringValue, "False");
-                Assert.AreEqual(result.ArrayValue, null);
-                Assert.AreEqual(result.Priority, null);
-                Assert.AreEqual(result.Reliability, null);
-                Assert.AreEqual(result.IsReliable, false);
+                Assert.AreEqual(0, result.NumericValue);
+                Assert.AreEqual("False", result.StringValue);
+                Assert.AreEqual(null, result.ArrayValue);                
+                Assert.AreEqual(null, result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -284,21 +285,21 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": {" +
                 "\"value\": 60, \"reliability\": \"reliabilityEnumSet.reliable\", \"priority\": \"writePriorityEnumSet.priorityNone\"} } }");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 60);
-                Assert.AreEqual(result.StringValue, "60");
-                Assert.AreEqual(result.ArrayValue, null);
-                Assert.AreEqual(result.Priority, "writePriorityEnumSet.priorityNone");
-                Assert.AreEqual(result.Reliability, "reliabilityEnumSet.reliable");
-                Assert.AreEqual(result.IsReliable, true);
+                Assert.AreEqual(60, result.NumericValue);
+                Assert.AreEqual("60", result.StringValue);
+                Assert.AreEqual(null, result.ArrayValue);
+                Assert.AreEqual("writePriorityEnumSet.priorityNone", result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -308,21 +309,21 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": {" +
                 "\"value\": \"stringvalue\", \"reliability\": \"reliabilityEnumSet.reliable\", \"priority\": \"writePriorityEnumSet.priorityNone\"} } }");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 0);
-                Assert.AreEqual(result.StringValue, "stringvalue");
-                Assert.AreEqual(result.ArrayValue, null);
-                Assert.AreEqual(result.Priority, "writePriorityEnumSet.priorityNone");
-                Assert.AreEqual(result.Reliability, "reliabilityEnumSet.reliable");
-                Assert.AreEqual(result.IsReliable, true);
+                Assert.AreEqual(0, result.NumericValue);
+                Assert.AreEqual("stringvalue", result.StringValue);
+                Assert.AreEqual(null, result.ArrayValue);
+                Assert.AreEqual("writePriorityEnumSet.priorityNone", result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -332,22 +333,22 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": { " +
                 "\"property\": \"stringvalue\", \"property2\": \"stringvalue2\", "+
-                "\"reliability\": \"reliabilityEnumSet.reliable\", \"priority\": \"writePriorityEnumSet.priorityNone\"} } }");
+                "\"reliability\": \"reliabilityEnumSet.noInput\", \"priority\": \"writePriorityEnumSet.priorityDefault\"} } }");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 0);
-                Assert.AreEqual(result.StringValue, "stringvalue");
-                Assert.AreEqual(result.ArrayValue, null);
-                Assert.AreEqual(result.Priority, "writePriorityEnumSet.priorityNone");
-                Assert.AreEqual(result.Reliability, "reliabilityEnumSet.reliable");
-                Assert.AreEqual(result.IsReliable, true);
+                Assert.AreEqual(0, result.NumericValue);
+                Assert.AreEqual("stringvalue", result.StringValue);
+                Assert.AreEqual(null, result.ArrayValue);
+                Assert.AreEqual("writePriorityEnumSet.priorityDefault", result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.noInput", result.Reliability);
+                Assert.AreEqual(false, result.IsReliable);
             }
         }
 
@@ -357,22 +358,22 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
                 "1, 2 ] } }");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 0);
-                Assert.AreEqual(result.StringValue, "Array");
-                Assert.AreEqual(result.ArrayValue[0], ("1", 1));
-                Assert.AreEqual(result.ArrayValue[1], ("2", 2));
-                Assert.AreEqual(result.Priority, null);
-                Assert.AreEqual(result.Reliability, null);
-                Assert.AreEqual(result.IsReliable, false);
+                Assert.AreEqual(0, result.NumericValue);
+                Assert.AreEqual("Array", result.StringValue);
+                Assert.AreEqual(("1", 1, true), result.ArrayValue[0]);
+                Assert.AreEqual(("2", 2, true), result.ArrayValue[1]);
+                Assert.AreEqual(null, result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -382,22 +383,22 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
                 "\"stringvalue1\", \"stringvalue2\" ] } }");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 0);
-                Assert.AreEqual(result.StringValue, "Array");
-                Assert.AreEqual(result.ArrayValue[0], ("stringvalue1", 0));
-                Assert.AreEqual(result.ArrayValue[1], ("stringvalue2", 0));
-                Assert.AreEqual(result.Priority, null);
-                Assert.AreEqual(result.Reliability, null);
-                Assert.AreEqual(result.IsReliable, false);
+                Assert.AreEqual(0, result.NumericValue);
+                Assert.AreEqual("Array", result.StringValue);
+                Assert.AreEqual(("stringvalue1", 0, false), result.ArrayValue[0]);
+                Assert.AreEqual(("stringvalue2", 0, false), result.ArrayValue[1]);
+                Assert.AreEqual(null, result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -407,23 +408,23 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
                 "{ \"item1\": \"stringvalue1\", \"item2\": \"stringvalue2\" }," +
                 "{ \"item1\": \"stringvalue3\", \"item2\": \"stringvalue4\" } ] } }");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 0);
-                Assert.AreEqual(result.StringValue, "Array");
-                Assert.AreEqual(result.ArrayValue[0], ("Unsupported Data Type", 1));
-                Assert.AreEqual(result.ArrayValue[1], ("Unsupported Data Type", 1));
-                Assert.AreEqual(result.Priority, null);
-                Assert.AreEqual(result.Reliability, null);
-                Assert.AreEqual(result.IsReliable, false);
+                Assert.AreEqual(0, result.NumericValue);
+                Assert.AreEqual("Array", result.StringValue);
+                Assert.AreEqual(("Unsupported Data Type", 1, false), result.ArrayValue[0]);
+                Assert.AreEqual(("Unsupported Data Type", 1, false), result.ArrayValue[1]);
+                Assert.AreEqual(null, result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -433,14 +434,14 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Not Found", 404);
                 try {
                     ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
                     Assert.Fail();
                 } catch {
-                    httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 }
@@ -453,20 +454,20 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": {}");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(result.NumericValue, 1);
-                Assert.AreEqual(result.StringValue, "Unsupported Data Type");
-                Assert.AreEqual(result.ArrayValue, null);
-                Assert.AreEqual(result.Priority, null);
-                Assert.AreEqual(result.Reliability, null);
-                Assert.AreEqual(result.IsReliable, false);
+                Assert.AreEqual(1, result.NumericValue);
+                Assert.AreEqual("Unsupported Data Type", result.StringValue);
+                Assert.AreEqual(null, result.ArrayValue);
+                Assert.AreEqual(null, result.Priority);
+                Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
+                Assert.AreEqual(true, result.IsReliable);
             }
         }
 
@@ -476,14 +477,14 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": \"stringvalue\" } }");
                 List<Guid> ids = new List<Guid>() { };
                 List<string> attributes = new List<string>() { mockAttributeName };
                 IEnumerable<ReadPropertyResult> results = traditionalClient.ReadPropertyMultiple(ids, attributes);
 
-                Assert.AreEqual(results.Count(), 0);
+                Assert.AreEqual(0, results.Count());
             }
         }
 
@@ -493,17 +494,17 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": \"stringvalue\" } }");
                 List<Guid> ids = new List<Guid>() { mockid };
                 List<string> attributes = new List<string>() { };
                 IEnumerable<ReadPropertyResult> results = traditionalClient.ReadPropertyMultiple(ids, attributes);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(results.Count(), 0);
+                Assert.AreEqual(0, results.Count());
             }
         }
 
@@ -513,17 +514,17 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": \"stringvalue\" } }");
                 List<Guid> ids = new List<Guid>() { mockid };
                 List<string> attributes = new List<string>() { mockAttributeName };
                 IEnumerable<ReadPropertyResult> results = traditionalClient.ReadPropertyMultiple(ids, attributes);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(results.Count(), 1);
+                Assert.AreEqual(1, results.Count());
             }
         }
 
@@ -533,7 +534,7 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 string mockAttributeName2 = "property2";
                 string mockAttributeName3 = "property3";
@@ -557,15 +558,15 @@ namespace Tests
                 List<string> attributes = new List<string>() { mockAttributeName, mockAttributeName2, mockAttributeName3, mockAttributeName4, mockAttributeName5 };
                 IEnumerable<ReadPropertyResult> results = traditionalClient.ReadPropertyMultiple(ids, attributes);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid2}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid2}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 Assert.AreEqual(results.Count(), 10);
                 foreach (var result in results) {
-                    Assert.AreNotEqual(result.StringValue, "Unsupported Data Type");
+                    Assert.AreNotEqual("Unsupported Data Type", result.StringValue);
                 }
             }
         }
@@ -576,17 +577,17 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
-                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"attributeNoMatch\": \"stringvalue\" } }");
                 List<Guid> ids = new List<Guid>() { mockid };
                 List<string> attributes = new List<string>() { mockAttributeName };
                 IEnumerable<ReadPropertyResult> results = traditionalClient.ReadPropertyMultiple(ids, attributes);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(results.Count(), 0);
+                Assert.AreEqual(0, results.Count());
             }
         }
     }

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -175,6 +175,27 @@ namespace Tests
             }
         }
 
+        [Test]
+        public void TestRefreshTimer()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                DateTime future = DateTime.Now;
+                future.AddSeconds(5);
+                string time = future.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'");
+
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = time });
+                traditionalClient.TryLogin("username", "password", "hostname");
+
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
+                System.Threading.Thread.Sleep(7000);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/refreshToken")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+            }
+        }
+
         #endregion
 
         #region GetObjectIdentifier Tests

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -2,12 +2,23 @@ using System;
 using System.Net.Http;
 using Flurl.Http.Testing;
 using NUnit.Framework;
+using Newtonsoft.Json.Linq;
 using JohnsonControls.Metasys.BasicServices;
+
 
 namespace Tests
 {
     public class TraditionalClientTests
     {
+        Guid mockid;
+        string mockAttributeName;
+
+        [SetUp]
+        public void Init()
+        {
+            mockAttributeName = "property";
+            mockid = new Guid("11111111-2222-3333-4444-555555555555");
+        }
 
         [Test]
         public void TestLogin()
@@ -106,7 +117,7 @@ namespace Tests
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
                 var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
 
-                httpTest.RespondWith("11111111-2222-3333-4444-555555555555");
+                httpTest.RespondWith(mockid.ToString());
                 var id = traditionalClient.GetObjectIdentifier("fully:qualified/reference");
                 httpTest.ShouldHaveCalled($"https://hostname/api/v2/objectIdentifiers")
                 .WithVerb(HttpMethod.Get)
@@ -132,6 +143,66 @@ namespace Tests
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 }
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyInteger()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": 1 }}");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 1);
+                Assert.AreEqual(result.StringValue, "1");
+                Assert.AreEqual(result.ArrayValue, null);
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyFloat()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": 1.1 }}");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 1.1);
+                Assert.AreEqual(result.StringValue, "1.1");
+                Assert.AreEqual(result.ArrayValue, null);
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyString()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": \"stringvalue\" }}");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 0);
+                Assert.AreEqual(result.StringValue, "stringvalue");
+                Assert.AreEqual(result.ArrayValue, null);
             }
         }
     }

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -1594,6 +1594,36 @@ namespace Tests
         }
 
         [Test]
+        public void TestGetNetworkDevicesMissingValues()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
+                traditionalClient.TryLogin("username", "password", "hostname");
+
+                httpTest.RespondWith(string.Concat("{",
+                    "\"total\": 1,",
+                    "\"next\": null,",
+                    "\"previous\": null,",
+                    "\"items\": [{}],",
+                    "\"self\": \"https://hostname/api/V2/networkDevices?page=1&pageSize=200&sort=name\"}"));
+
+                var devices = traditionalClient.GetNetworkDevices().ToList();
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(1, devices.Count);
+                Assert.AreEqual(Guid.Empty, devices[0].Id);
+                Assert.AreEqual("N/A", devices[0].ItemReference);
+                Assert.AreEqual("N/A", devices[0].Name);
+                Assert.AreEqual("N/A", devices[0].TypeUrl);
+                Assert.AreEqual("N/A", devices[0].Description);
+                Assert.AreEqual("N/A", devices[0].FirmwareVersion);
+                Assert.AreEqual("N/A", devices[0].IpAddress);
+            }
+        }
+
+        [Test]
         public void TestGetNetworkDevicesNullClient()
         {
             using (var httpTest = new HttpTest())

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -1508,22 +1508,31 @@ namespace Tests
                         "\"id\": \"", mockid, "\",",
                         "\"itemReference\": \"fully:qualified/reference\",",
                         "\"name\": \"name\",",
-                        "\"typeUrl\": \"https://hostname/api/v2/enumSets/508/members/197\",",
+                        "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\",",
                         "\"description\": \"none\",",
                         "\"firmwareVersion\": \"4.0.0.1105\",",
                         "\"ipAddress\": \"\"",
                     "}],",
                     "\"self\": \"https://hostname/api/V2/networkDevices?page=1&pageSize=200&sort=name\"}"));
 
+                httpTest.RespondWith(string.Concat("{",
+                    "\"id\": 197,",
+                    "\"description\": \"JCI Family BACnet Device\",",
+                    "\"self\": \"https://hostname/api/V2/enumSets/508/members/197\",",
+                    "\"setUrl\": \"https://hostname/api/V2/enumSets/508\"}"));
+                
                 var devices = traditionalClient.GetNetworkDevices().ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/enumSets/508/members/197")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 Assert.AreEqual(1, devices.Count);
                 Assert.AreEqual(mockid, devices[0].Id);
                 Assert.AreEqual("fully:qualified/reference", devices[0].ItemReference);
                 Assert.AreEqual("name", devices[0].Name);
-                Assert.AreEqual("https://hostname/api/v2/enumSets/508/members/197", devices[0].TypeUrl);
+                Assert.AreEqual("JCI Family BACnet Device", devices[0].Type);
                 Assert.AreEqual("none", devices[0].Description);
                 Assert.AreEqual("4.0.0.1105", devices[0].FirmwareVersion);
                 Assert.AreEqual("", devices[0].IpAddress);
@@ -1546,7 +1555,7 @@ namespace Tests
                         "\"id\": \"", mockid, "\",",
                         "\"itemReference\": \"fully:qualified/reference\",",
                         "\"name\": \"name\",",
-                        "\"typeUrl\": \"https://hostname/api/v2/enumSets/508/members/197\",",
+                        "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\",",
                         "\"description\": \"none\",",
                         "\"firmwareVersion\": \"4.0.0.1105\",",
                         "\"ipAddress\": \"\"",
@@ -1561,7 +1570,7 @@ namespace Tests
                         "\"id\": \"", mockid, "\",",
                         "\"itemReference\": \"fully:qualified/reference\",",
                         "\"name\": \"name\",",
-                        "\"typeUrl\": \"https://hostname/api/v2/enumSets/508/members/197\",",
+                        "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\",",
                         "\"description\": \"none\",",
                         "\"firmwareVersion\": \"4.0.0.1105\",",
                         "\"ipAddress\": \"\"},",
@@ -1569,15 +1578,26 @@ namespace Tests
                         "{\"id\": \"", mockid2, "\",",
                         "\"itemReference\": \"fully:qualified/reference2\",",
                         "\"name\": \"name\",",
-                        "\"typeUrl\": \"https://hostname/api/v2/enumSets/508/members/197\",",
+                        "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\",",
                         "\"description\": \"none\",",
                         "\"firmwareVersion\": \"4.0.0.1105\",",
                         "\"ipAddress\": \"\"",
                     "}],",
                     "\"self\": \"https://hostname/api/V2/networkDevices?page=1&pageSize=2&sort=name\"}"));
 
+                string member = string.Concat("{",
+                    "\"id\": 197,",
+                    "\"description\": \"JCI Family BACnet Device\",",
+                    "\"self\": \"https://hostname/api/V2/enumSets/508/members/197\",",
+                    "\"setUrl\": \"https://hostname/api/V2/enumSets/508\"}");
+                httpTest.RespondWith(member);
+                httpTest.RespondWith(member);
+
                 var devices = traditionalClient.GetNetworkDevices().ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(2);
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/enumSets/508/members/197")
                     .WithVerb(HttpMethod.Get)
                     .Times(2);
                 Assert.AreEqual(2, devices.Count);
@@ -1600,22 +1620,31 @@ namespace Tests
                         "\"id\": \"", mockid, "\",",
                         "\"itemReference\": \"fully:qualified/reference\",",
                         "\"name\": \"name\",",
-                        "\"typeUrl\": \"https://hostname/api/v2/enumSets/508/members/197\",",
+                        "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\",",
                         "\"description\": \"none\",",
                         "\"firmwareVersion\": \"4.0.0.1105\",",
                         "\"ipAddress\": \"\"",
                     "}],",
                     "\"self\": \"https://hostname/api/V2/networkDevices?page=1&pageSize=200&sort=name\"}"));
 
+                httpTest.RespondWith(string.Concat("{",
+                    "\"id\": 197,",
+                    "\"description\": \"JCI Family BACnet Device\",",
+                    "\"self\": \"https://hostname/api/V2/enumSets/508/members/197\",",
+                    "\"setUrl\": \"https://hostname/api/V2/enumSets/508\"}"));
+
                 var devices = traditionalClient.GetNetworkDevices("197").ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/enumSets/508/members/197")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 Assert.AreEqual(1, devices.Count);
                 Assert.AreEqual(mockid, devices[0].Id);
                 Assert.AreEqual("fully:qualified/reference", devices[0].ItemReference);
                 Assert.AreEqual("name", devices[0].Name);
-                Assert.AreEqual("https://hostname/api/v2/enumSets/508/members/197", devices[0].TypeUrl);
+                Assert.AreEqual("JCI Family BACnet Device", devices[0].Type);
                 Assert.AreEqual("none", devices[0].Description);
                 Assert.AreEqual("4.0.0.1105", devices[0].FirmwareVersion);
                 Assert.AreEqual("", devices[0].IpAddress);
@@ -1643,12 +1672,12 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(1, devices.Count);
                 Assert.AreEqual(Guid.Empty, devices[0].Id);
-                Assert.AreEqual("N/A", devices[0].ItemReference);
-                Assert.AreEqual("N/A", devices[0].Name);
-                Assert.AreEqual("N/A", devices[0].TypeUrl);
-                Assert.AreEqual("N/A", devices[0].Description);
-                Assert.AreEqual("N/A", devices[0].FirmwareVersion);
-                Assert.AreEqual("N/A", devices[0].IpAddress);
+                Assert.AreEqual("", devices[0].ItemReference);
+                Assert.AreEqual("", devices[0].Name);
+                Assert.AreEqual("", devices[0].Type);
+                Assert.AreEqual("", devices[0].Description);
+                Assert.AreEqual("", devices[0].FirmwareVersion);
+                Assert.AreEqual("", devices[0].IpAddress);
             }
         }
 
@@ -1799,7 +1828,7 @@ namespace Tests
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/enumSets/508/members/3000")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
-                Assert.AreEqual(0, types.Count);
+                Assert.AreEqual(1, types.Count);
             }
         }
 
@@ -1813,6 +1842,175 @@ namespace Tests
                     var types = traditionalClient.GetNetworkDeviceTypes();
                     httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/networkDevices/availableTypes");
                     Assert.AreEqual(null, types);
+                }
+                catch
+                {
+                    Assert.Fail();
+                }
+            }
+        }
+
+        #endregion
+
+        #region TestGetObjects
+
+        [Test]
+        public void TestGetObjectsNone()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
+                traditionalClient.TryLogin("username", "password", "hostname");
+
+                httpTest.RespondWith(string.Concat("{",
+                    "\"total\": 0,",
+                    "\"next\": null,",
+                    "\"previous\": null,",
+                    "\"items\": [ ],",
+                    "\"self\": \"https://hostname/api/V2/objects/{mockid}/objects?page=1&pageSize=200&sort=name\"}"));
+
+                var objects = traditionalClient.GetObjects(mockid).ToList();
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/objects")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(0, objects.Count);
+            }
+        }
+
+        [Test]
+        public void TestGetObjectsOnePage()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
+                traditionalClient.TryLogin("username", "password", "hostname");
+
+                httpTest.RespondWith(string.Concat("{",
+                    "\"total\": 1,",
+                    "\"next\": null,",
+                    "\"previous\": null,",
+                    "\"items\": [{",
+                        "\"id\": \"", mockid, "\",",
+                        "\"itemReference\": \"fully:qualified/reference\",",
+                        "\"name\": \"name\",",
+                        "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\"",
+                    "}],",
+                    "\"self\": \"https://hostname/api/V2/objects/{mockid}/objects?page=1&pageSize=200&sort=name\"}"));
+
+                httpTest.RespondWith(string.Concat("{",
+                    "\"id\": 197,",
+                    "\"description\": \"JCI Family BACnet Device\",",
+                    "\"self\": \"https://hostname/api/V2/enumSets/508/members/197\",",
+                    "\"setUrl\": \"https://hostname/api/V2/enumSets/508\"}"));
+                
+                var objects = traditionalClient.GetObjects(mockid).ToList();
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/objects")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/enumSets/508/members/197")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(1, objects.Count);
+                Assert.AreEqual(mockid, objects[0].Id);
+                Assert.AreEqual("fully:qualified/reference", objects[0].ItemReference);
+                Assert.AreEqual("name", objects[0].Name);
+                Assert.AreEqual("JCI Family BACnet Device", objects[0].Type);
+            }
+        }
+
+        [Test]
+        public void TestGetObjectsManyPages()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
+                traditionalClient.TryLogin("username", "password", "hostname");
+
+                httpTest.RespondWith(string.Concat("{",
+                    "\"total\": 2,",
+                    "\"next\": \"https://hostname/api/V2/objects/{mockid}/objects?page=2&pageSize=1&sort=name\",",
+                    "\"previous\": null,",
+                    "\"items\": [{",
+                        "\"id\": \"", mockid, "\",",
+                        "\"itemReference\": \"fully:qualified/reference\",",
+                        "\"name\": \"name\",",
+                        "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\"",
+                    "}],",
+                    "\"self\": \"https://hostname/api/V2/objects/{mockid}/objects?page=1&pageSize=1&sort=name\"}"));
+
+                httpTest.RespondWith(string.Concat("{",
+                    "\"total\": 2,",
+                    "\"next\": null,",
+                    "\"previous\": null,",
+                    "\"items\": [{",
+                        "\"id\": \"", mockid, "\",",
+                        "\"itemReference\": \"fully:qualified/reference\",",
+                        "\"name\": \"name\",",
+                        "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\"},",
+
+                        "{\"id\": \"", mockid2, "\",",
+                        "\"itemReference\": \"fully:qualified/reference2\",",
+                        "\"name\": \"name\",",
+                        "\"typeUrl\": \"https://hostname/api/V2/enumSets/508/members/197\"",
+                    "}],",
+                    "\"self\": \"https://hostname/api/V2/objects/{mockid}/objects?page=1&pageSize=2&sort=name\"}"));
+
+                string member = string.Concat("{",
+                    "\"id\": 197,",
+                    "\"description\": \"JCI Family BACnet Device\",",
+                    "\"self\": \"https://hostname/api/V2/enumSets/508/members/197\",",
+                    "\"setUrl\": \"https://hostname/api/V2/enumSets/508\"}");
+                httpTest.RespondWith(member);
+                httpTest.RespondWith(member);
+                
+                var objects = traditionalClient.GetObjects(mockid).ToList();
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/objects")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(2);
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/enumSets/508/members/197")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(2);
+                Assert.AreEqual(2, objects.Count);
+            }
+        }
+
+        [Test]
+        public void TestGetObjectsMissingValues()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
+                traditionalClient.TryLogin("username", "password", "hostname");
+
+                httpTest.RespondWith(string.Concat("{",
+                    "\"total\": 1,",
+                    "\"next\": null,",
+                    "\"previous\": null,",
+                    "\"items\": [{}],",
+                    "\"self\": \"https://hostname/api/V2/objects/{mockid}/objects?page=1&pageSize=200&sort=name\"}"));
+
+                var objects = traditionalClient.GetObjects(mockid).ToList();
+                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/objects")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(1, objects.Count);
+                Assert.AreEqual(Guid.Empty, objects[0].Id);
+                Assert.AreEqual("", objects[0].ItemReference);
+                Assert.AreEqual("", objects[0].Name);
+                Assert.AreEqual("", objects[0].Type);
+            }
+        }
+
+        [Test]
+        public void TestGetObjectsNullClient()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                try
+                {
+                    var objects = traditionalClient.GetObjects(mockid);
+                    httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objects/{mockid}/objects");
+                    Assert.AreEqual(null, objects);
                 }
                 catch
                 {

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -216,6 +216,52 @@ namespace Tests
         }
 
         [Test]
+        public void TestReadPropertyBooleanTrue()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": true }}");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 1);
+                Assert.AreEqual(result.StringValue, "True");
+                Assert.AreEqual(result.ArrayValue, null);
+                Assert.AreEqual(result.Priority, null);
+                Assert.AreEqual(result.Reliability, null);
+                Assert.AreEqual(result.IsReliable, false);
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyBooleanFalse()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": false }}");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 0);
+                Assert.AreEqual(result.StringValue, "False");
+                Assert.AreEqual(result.ArrayValue, null);
+                Assert.AreEqual(result.Priority, null);
+                Assert.AreEqual(result.Reliability, null);
+                Assert.AreEqual(result.IsReliable, false);
+            }
+        }
+
+        [Test]
         public void TestReadPropertyObjectWithReliabilityPriorityInteger()
         {
             using (var httpTest = new HttpTest())
@@ -347,7 +393,8 @@ namespace Tests
                 var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
-                "{ \"item1\": \"stringvalue1\", \"item2\": \"stringvalue2\" } ] } }");
+                "{ \"item1\": \"stringvalue1\", \"item2\": \"stringvalue2\" }," +
+                "{ \"item1\": \"stringvalue3\", \"item2\": \"stringvalue4\" } ] } }");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
                 httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
@@ -356,6 +403,7 @@ namespace Tests
                 Assert.AreEqual(result.NumericValue, 0);
                 Assert.AreEqual(result.StringValue, "Array");
                 Assert.AreEqual(result.ArrayValue[0], ("Unsupported Data Type", 1));
+                Assert.AreEqual(result.ArrayValue[1], ("Unsupported Data Type", 1));
                 Assert.AreEqual(result.Priority, null);
                 Assert.AreEqual(result.Reliability, null);
                 Assert.AreEqual(result.IsReliable, false);

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -8,21 +8,14 @@ namespace Tests
 {
     public class TraditionalClientTests
     {
-        TraditionalClient traditionalClient;
-
-        // [SetUp]
-        // public void Setup()
-        // {
-        //     //traditionalClient = new TraditionalClient();
-        // }
 
         [Test]
         public void TestLogin()
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2020-01-01T00:00:00Z"});
-                traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
                 httpTest.ShouldHaveCalled($"https://hostname/api/v2/login")
                     .WithVerb(HttpMethod.Post)
                     .WithContentType("application/json")
@@ -32,15 +25,57 @@ namespace Tests
         }
 
         [Test]
+        public void TestUnauthorizedLoginThrowsException()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWith("unauthorized", 401);
+                try {
+                    var traditionalClient = new TraditionalClient("username", "badpassword", "hostname", 2);
+                    Assert.Fail();
+                } catch {
+                    httpTest.ShouldHaveCalled($"https://hostname/api/v2/login")
+                    .WithVerb(HttpMethod.Post)
+                    .WithContentType("application/json")
+                    .WithRequestBody("{\"username\":\"username\",\"password\":\"badpassword\"")
+                    .Times(1);
+                }
+            }
+        }
+
+        [Test]
         public void TestRefresh()
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2020-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+                
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
                 traditionalClient.Refresh();
                 httpTest.ShouldHaveCalled($"https://hostname/api/v2/refreshToken")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
+            }
+        }
+
+        [Test]
+        public void TestRefreshThrowsException()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("unauthorized", 401);
+                try {
+                    traditionalClient.Refresh();
+                    Assert.Fail();
+                } catch {
+                    httpTest.ShouldHaveCalled($"https://hostname/api/v2/refreshToken")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                }
             }
         }
     }

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -542,13 +542,13 @@ namespace Tests
                 try
                 {
                     ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
-                    Assert.Fail();
+                    httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
+                        .WithVerb(HttpMethod.Get)
+                        .Times(1);
                 }
                 catch
                 {
-                    httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
-                    .WithVerb(HttpMethod.Get)
-                    .Times(1);
+                    Assert.Fail();
                 }
             }
         }
@@ -711,12 +711,20 @@ namespace Tests
                 httpTest.RespondWith("{ \"item\": { \"attributeNoMatch\": \"stringvalue\" } }");
                 List<Guid> ids = new List<Guid>() { mockid };
                 List<string> attributes = new List<string>() { mockAttributeName };
-                IEnumerable<ReadPropertyResult> results = traditionalClient.ReadPropertyMultiple(ids, attributes);
 
-                httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
-                    .WithVerb(HttpMethod.Get)
-                    .Times(1);
-                Assert.AreEqual(0, results.Count());
+                try
+                {
+                    IEnumerable<ReadPropertyResult> results = traditionalClient.ReadPropertyMultiple(ids, attributes);
+
+                    httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
+                        .WithVerb(HttpMethod.Get)
+                        .Times(1);
+                    Assert.AreEqual(1, results.Count());
+                }
+                catch
+                {
+                    Assert.Fail();
+                }
             }
         }
 

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -44,13 +44,32 @@ namespace Tests
         }
 
         [Test]
+        public void TestBadHostLoginThrowsException()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWith("Call failed. No such host is known POST https://badhost/api/v2/login");
+                try {
+                    var traditionalClient = new TraditionalClient("username", "password", "badhost", 2);
+                    Assert.Fail();
+                } catch {
+                    httpTest.ShouldHaveCalled($"https://badhost/api/v2/login")
+                    .WithVerb(HttpMethod.Post)
+                    .WithContentType("application/json")
+                    .WithRequestBody("{\"username\":\"username\",\"password\":\"password\"")
+                    .Times(1);
+                }
+            }
+        }
+
+        [Test]
         public void TestRefresh()
         {
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
                 var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
-                
+
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
                 traditionalClient.Refresh();
                 httpTest.ShouldHaveCalled($"https://hostname/api/v2/refreshToken")
@@ -73,6 +92,43 @@ namespace Tests
                     Assert.Fail();
                 } catch {
                     httpTest.ShouldHaveCalled($"https://hostname/api/v2/refreshToken")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                }
+            }
+        }
+
+        [Test]
+        public void TestGetObjectIdentifier()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("11111111-2222-3333-4444-555555555555");
+                var id = traditionalClient.GetObjectIdentifier("fully:qualified/reference");
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objectIdentifiers")
+                .WithVerb(HttpMethod.Get)
+                .Times(1);
+                Assert.AreEqual(id.GetType(), typeof(Guid));
+            }
+        }
+
+        [Test]
+        public void TestGetBadObjectIdentifierThrowsException()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("Bad Request", 400);
+                try {
+                    var id = traditionalClient.GetObjectIdentifier("fully:qualified/reference");
+                    Assert.Fail();
+                } catch {
+                    httpTest.ShouldHaveCalled($"https://hostname/api/v2/objectIdentifiers")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 }

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -74,6 +74,21 @@ namespace Tests
         }
 
         [Test]
+        public void TestBadVersionLogin()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 1);
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/login")
+                    .WithVerb(HttpMethod.Post)
+                    .WithContentType("application/json")
+                    .WithRequestBody("{\"username\":\"username\",\"password\":\"password\"")
+                    .Times(1);
+            }
+        }
+
+        [Test]
         public void TestRefresh()
         {
             using (var httpTest = new HttpTest())

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -163,6 +163,9 @@ namespace Tests
                 Assert.AreEqual(result.NumericValue, 1);
                 Assert.AreEqual(result.StringValue, "1");
                 Assert.AreEqual(result.ArrayValue, null);
+                Assert.AreEqual(result.Priority, null);
+                Assert.AreEqual(result.Reliability, null);
+                Assert.AreEqual(result.IsReliable, false);
             }
         }
 
@@ -183,6 +186,9 @@ namespace Tests
                 Assert.AreEqual(result.NumericValue, 1.1);
                 Assert.AreEqual(result.StringValue, "1.1");
                 Assert.AreEqual(result.ArrayValue, null);
+                Assert.AreEqual(result.Priority, null);
+                Assert.AreEqual(result.Reliability, null);
+                Assert.AreEqual(result.IsReliable, false);
             }
         }
 
@@ -203,6 +209,156 @@ namespace Tests
                 Assert.AreEqual(result.NumericValue, 0);
                 Assert.AreEqual(result.StringValue, "stringvalue");
                 Assert.AreEqual(result.ArrayValue, null);
+                Assert.AreEqual(result.Priority, null);
+                Assert.AreEqual(result.Reliability, null);
+                Assert.AreEqual(result.IsReliable, false);
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyObjectWithReliabilityPriorityInteger()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": {" +
+                "\"value\": 60, \"reliability\": \"reliabilityEnumSet.reliable\", \"priority\": \"writePriorityEnumSet.priorityNone\"} } }");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 60);
+                Assert.AreEqual(result.StringValue, "60");
+                Assert.AreEqual(result.ArrayValue, null);
+                Assert.AreEqual(result.Priority, "writePriorityEnumSet.priorityNone");
+                Assert.AreEqual(result.Reliability, "reliabilityEnumSet.reliable");
+                Assert.AreEqual(result.IsReliable, true);
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyObjectWithReliabilityPriorityString()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": {" +
+                "\"value\": \"stringvalue\", \"reliability\": \"reliabilityEnumSet.reliable\", \"priority\": \"writePriorityEnumSet.priorityNone\"} } }");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 0);
+                Assert.AreEqual(result.StringValue, "stringvalue");
+                Assert.AreEqual(result.ArrayValue, null);
+                Assert.AreEqual(result.Priority, "writePriorityEnumSet.priorityNone");
+                Assert.AreEqual(result.Reliability, "reliabilityEnumSet.reliable");
+                Assert.AreEqual(result.IsReliable, true);
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyObjectWithReliabilityPriorityStringNoValueField()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": { " +
+                "\"property\": \"stringvalue\", \"property2\": \"stringvalue2\", "+
+                "\"reliability\": \"reliabilityEnumSet.reliable\", \"priority\": \"writePriorityEnumSet.priorityNone\"} } }");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 0);
+                Assert.AreEqual(result.StringValue, "stringvalue");
+                Assert.AreEqual(result.ArrayValue, null);
+                Assert.AreEqual(result.Priority, "writePriorityEnumSet.priorityNone");
+                Assert.AreEqual(result.Reliability, "reliabilityEnumSet.reliable");
+                Assert.AreEqual(result.IsReliable, true);
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyArrayIntegers()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
+                "1, 2 ] } }");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 0);
+                Assert.AreEqual(result.StringValue, "Array");
+                Assert.AreEqual(result.ArrayValue[0], ("1", 1));
+                Assert.AreEqual(result.ArrayValue[1], ("2", 2));
+                Assert.AreEqual(result.Priority, null);
+                Assert.AreEqual(result.Reliability, null);
+                Assert.AreEqual(result.IsReliable, false);
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyArrayStrings()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
+                "\"stringvalue1\", \"stringvalue2\" ] } }");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 0);
+                Assert.AreEqual(result.StringValue, "Array");
+                Assert.AreEqual(result.ArrayValue[0], ("stringvalue1", 0));
+                Assert.AreEqual(result.ArrayValue[1], ("stringvalue2", 0));
+                Assert.AreEqual(result.Priority, null);
+                Assert.AreEqual(result.Reliability, null);
+                Assert.AreEqual(result.IsReliable, false);
+            }
+        }
+
+        [Test]
+        public void TestReadPropertyArrayObjectUnsupported()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
+                "{ \"item1\": \"stringvalue1\", \"item2\": \"stringvalue2\" } ] } }");
+                ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}/attributes/{mockAttributeName}")
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+                Assert.AreEqual(result.NumericValue, 0);
+                Assert.AreEqual(result.StringValue, "Array");
+                Assert.AreEqual(result.ArrayValue[0], ("Unsupported Data Type", 1));
+                Assert.AreEqual(result.Priority, null);
+                Assert.AreEqual(result.Reliability, null);
+                Assert.AreEqual(result.IsReliable, false);
             }
         }
     }

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -40,7 +40,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/login")
                     .WithVerb(HttpMethod.Post)
@@ -57,18 +57,21 @@ namespace Tests
             {
                 httpTest.RespondWith("unauthorized", 401);
 
-                try {
+                try
+                {
                     traditionalClient.TryLogin("username", "badpassword", "hostname");
 
                     httpTest.ShouldHaveCalled($"https://hostname/api/V2/login")
                         .WithVerb(HttpMethod.Post)
                         .WithContentType("application/json")
                         .WithRequestBody("{\"username\":\"username\",\"password\":\"badpassword\"")
-                        .Times(1);  
-                } catch {
+                        .Times(1);
+                }
+                catch
+                {
                     Assert.Fail();
                 }
-                
+
             }
         }
 
@@ -78,16 +81,19 @@ namespace Tests
             using (var httpTest = new HttpTest())
             {
                 httpTest.RespondWith("Call failed. No such host is known POST https://badhost/api/V2/login", 404);
-                
-                try {
+
+                try
+                {
                     traditionalClient.TryLogin("username", "password", "badhost");
-                
+
                     httpTest.ShouldHaveCalled($"https://badhost/api/V2/login")
                         .WithVerb(HttpMethod.Post)
                         .WithContentType("application/json")
                         .WithRequestBody("{\"username\":\"username\",\"password\":\"password\"")
-                        .Times(1); 
-                } catch {
+                        .Times(1);
+                }
+                catch
+                {
                     Assert.Fail();
                 }
             }
@@ -117,10 +123,10 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.Refresh();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/refreshToken")
                     .WithVerb(HttpMethod.Get)
@@ -129,12 +135,19 @@ namespace Tests
         }
 
         [Test]
-        public void TestRefreshClientUndefined()
+        public void TestRefreshNullClient()
         {
             using (var httpTest = new HttpTest())
             {
-                traditionalClient.Refresh();
-                httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/refreshToken");
+                try
+                {
+                    traditionalClient.Refresh();
+                    httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/refreshToken");
+                }
+                catch
+                {
+                    Assert.Fail();
+                }
             }
         }
 
@@ -143,20 +156,22 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("unauthorized", 401);
 
-                try {
+                try
+                {
                     traditionalClient.Refresh();
                     httpTest.ShouldHaveCalled($"https://hostname/api/V2/refreshToken")
                         .WithVerb(HttpMethod.Get)
                         .Times(1);
-                } catch {
+                }
+                catch
+                {
                     Assert.Fail();
                 }
-                
             }
         }
 
@@ -169,7 +184,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith($"\"{mockid.ToString()}\"");
@@ -186,7 +201,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Bad Request", 400);
@@ -204,7 +219,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Bad Request", 400);
@@ -222,14 +237,17 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                try {
+                try
+                {
                     var id = traditionalClient.GetObjectIdentifier("fully:qualified/reference");
                     httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objectIdentifiers");
                     Assert.AreEqual(Guid.Empty, id);
-                } catch {
+                }
+                catch
+                {
                     Assert.Fail();
                 }
-                
+
             }
         }
 
@@ -242,7 +260,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": 1 }}");
@@ -266,7 +284,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": 1.1 }}");
@@ -290,7 +308,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": \"stringvalue\" }}");
@@ -298,7 +316,7 @@ namespace Tests
 
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
-                    .Times(1);                
+                    .Times(1);
                 Assert.AreEqual(0, result.NumericValue);
                 Assert.AreEqual("stringvalue", result.StringValue);
                 Assert.AreEqual(false, result.BooleanValue);
@@ -314,7 +332,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": true }}");
@@ -326,7 +344,7 @@ namespace Tests
                 Assert.AreEqual(1, result.NumericValue);
                 Assert.AreEqual("True", result.StringValue);
                 Assert.AreEqual(true, result.BooleanValue);
-                Assert.AreEqual(null, result.ArrayValue);                
+                Assert.AreEqual(null, result.ArrayValue);
                 Assert.AreEqual(null, result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
                 Assert.AreEqual(true, result.IsReliable);
@@ -338,7 +356,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{\"item\": { \"" + mockAttributeName + "\": false }}");
@@ -350,7 +368,7 @@ namespace Tests
                 Assert.AreEqual(0, result.NumericValue);
                 Assert.AreEqual("False", result.StringValue);
                 Assert.AreEqual(false, result.BooleanValue);
-                Assert.AreEqual(null, result.ArrayValue);                
+                Assert.AreEqual(null, result.ArrayValue);
                 Assert.AreEqual(null, result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
                 Assert.AreEqual(true, result.IsReliable);
@@ -362,7 +380,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": {" +
@@ -387,7 +405,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": {" +
@@ -412,11 +430,11 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": { " +
-                "\"property\": \"stringvalue\", \"property2\": \"stringvalue2\", "+
+                "\"property\": \"stringvalue\", \"property2\": \"stringvalue2\", " +
                 "\"reliability\": \"reliabilityEnumSet.noInput\", \"priority\": \"writePriorityEnumSet.priorityDefault\"} } }");
                 ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
 
@@ -438,7 +456,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
@@ -464,7 +482,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
@@ -490,7 +508,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": [ " +
@@ -517,14 +535,17 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Not Found", 404);
-                try {
+                try
+                {
                     ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
                     Assert.Fail();
-                } catch {
+                }
+                catch
+                {
                     httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
@@ -537,7 +558,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": {}");
@@ -561,7 +582,8 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                try {
+                try
+                {
                     ReadPropertyResult result = traditionalClient.ReadProperty(mockid, mockAttributeName);
                     httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objects/{mockid}/attributes/{mockAttributeName}");
                     Assert.AreEqual(1, result.NumericValue);
@@ -571,7 +593,9 @@ namespace Tests
                     Assert.AreEqual(null, result.Priority);
                     Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
                     Assert.AreEqual(true, result.IsReliable);
-                } catch {
+                }
+                catch
+                {
                     Assert.Fail();
                 }
             }
@@ -586,7 +610,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": \"stringvalue\" } }");
@@ -603,7 +627,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": \"stringvalue\" } }");
@@ -623,7 +647,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"" + mockAttributeName + "\": \"stringvalue\" } }");
@@ -643,7 +667,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest
@@ -669,7 +693,8 @@ namespace Tests
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 Assert.AreEqual(results.Count(), 10);
-                foreach (var result in results) {
+                foreach (var result in results)
+                {
                     Assert.AreNotEqual("Unsupported Data Type", result.StringValue);
                 }
             }
@@ -680,7 +705,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("{ \"item\": { \"attributeNoMatch\": \"stringvalue\" } }");
@@ -695,6 +720,27 @@ namespace Tests
             }
         }
 
+        [Test]
+        public void TestReadPropertyMultipleNullClient()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                try
+                {
+                    List<Guid> ids = new List<Guid>() { mockid };
+                    List<string> attributes = new List<string>() { mockAttributeName };
+                    IEnumerable<ReadPropertyResult> results = traditionalClient.ReadPropertyMultiple(ids, attributes);
+
+                    httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objects/{mockid}");
+                    Assert.AreEqual(null, results);
+                }
+                catch
+                {
+                    Assert.Fail();
+                }
+            }
+        }
+
         #endregion
 
         #region WriteProperty Tests
@@ -704,7 +750,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
@@ -723,7 +769,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
@@ -742,7 +788,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
@@ -761,7 +807,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
@@ -780,7 +826,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
@@ -799,12 +845,12 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
 
-                traditionalClient.WriteProperty(mockid, mockAttributeName, new [] { "1", "2", "3" });
+                traditionalClient.WriteProperty(mockid, mockAttributeName, new[] { "1", "2", "3" });
 
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
                     .WithVerb(HttpMethod.Patch)
@@ -818,12 +864,12 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
 
-                traditionalClient.WriteProperty(mockid, mockAttributeName, new [] { 1, 2, 3 });
+                traditionalClient.WriteProperty(mockid, mockAttributeName, new[] { 1, 2, 3 });
 
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
                     .WithVerb(HttpMethod.Patch)
@@ -837,19 +883,40 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Bad Request", 400);
-                try {
+                try
+                {
                     traditionalClient.WriteProperty(mockid, mockAttributeName, "badType");
                     httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
                         .WithVerb(HttpMethod.Patch)
                         .WithRequestJson($"{{\"item\":{{\"{mockAttributeName}\":\"badType\"}}}}")
                         .Times(1);
-                } catch {
+                }
+                catch
+                {
                     Assert.Fail();
                 }
+            }
+        }
+
+        [Test]
+        public void TestWritePropertyNullClient()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                try
+                {
+                    traditionalClient.WriteProperty(mockid, mockAttributeName, "newValue");
+                    httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objects/{mockid}");
+                }
+                catch
+                {
+                    Assert.Fail();
+                }
+
             }
         }
 
@@ -862,7 +929,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
@@ -883,7 +950,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
@@ -908,13 +975,13 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Accepted", 202);
 
                 List<Guid> ids = new List<Guid>() { mockid, mockid2 };
-                List<(string, object)> attributes = new List<(string, object)>() { 
+                List<(string, object)> attributes = new List<(string, object)>() {
                     (mockAttributeName, "stringvalue"),
                     (mockAttributeName2, 23),
                     (mockAttributeName3, 23.5),
@@ -944,7 +1011,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Bad Request", 400);
@@ -952,13 +1019,16 @@ namespace Tests
                 List<Guid> ids = new List<Guid>() { mockid };
                 List<(string, object)> attributes = new List<(string, object)>() { ("badAttributeName", "newValue") };
 
-                try {
+                try
+                {
                     traditionalClient.WritePropertyMultiple(ids, attributes);
                     httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}")
                         .WithVerb(HttpMethod.Patch)
                         .WithRequestJson("{\"item\":{\"badAttributeName\":\"newValue\"}}")
                         .Times(1);
-                } catch {
+                }
+                catch
+                {
                     Assert.Fail();
                 }
             }
@@ -969,22 +1039,42 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Bad Request", 400);
 
-                try {
+                try
+                {
                     traditionalClient.WritePropertyMultiple(null, null);
                     httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objects/{mockid}");
-                } catch {
+                }
+                catch
+                {
+                    Assert.Fail();
+                }
+            }
+        }
+
+        [Test]
+        public void TestWritePropertyMultipleNullClient()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                try
+                {
+                    traditionalClient.WritePropertyMultiple(null, null);
+                    httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objects/{mockid}");
+                }
+                catch
+                {
                     Assert.Fail();
                 }
             }
         }
 
         #endregion
-    
+
         #region SendCommand Tests
 
         [Test]
@@ -992,11 +1082,11 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("OK", 200);
-                
+
                 traditionalClient.SendCommand(mockid, "EnableAlarms");
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands/EnableAlarms")
                     .WithVerb(HttpMethod.Put)
@@ -1009,7 +1099,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("OK", 200);
@@ -1027,7 +1117,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("OK", 200);
@@ -1045,7 +1135,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("OK", 200);
@@ -1063,18 +1153,21 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Bad Request", 400);
-                
-                try {
+
+                try
+                {
                     List<object> list = new List<object>() { "noMatch", "noMatch" };
                     traditionalClient.SendCommand(mockid, "Release", list);
                     httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands/Release")
                         .WithVerb(HttpMethod.Put)
                         .Times(1);
-                } catch {
+                }
+                catch
+                {
                     Assert.Fail();
                 }
             }
@@ -1085,25 +1178,46 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("Unauthorized", 401);
-                
-                try {
+
+                try
+                {
                     List<object> list = new List<object>() { 40, "badDataTypes" };
                     traditionalClient.SendCommand(mockid, "Release", list);
                     httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands/Release")
                         .WithVerb(HttpMethod.Put)
                         .Times(1);
-                } catch {
+                }
+                catch
+                {
+                    Assert.Fail();
+                }
+            }
+        }
+
+        [Test]
+        public void TestSendCommandNullClient()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                try
+                {
+                    List<object> list = new List<object>() { 40, "badDataTypes" };
+                    traditionalClient.SendCommand(mockid, "Release", list);
+                    httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands/Release");
+                }
+                catch
+                {
                     Assert.Fail();
                 }
             }
         }
 
         #endregion
-    
+
         #region GetCommands Tests
 
         [Test]
@@ -1111,11 +1225,11 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith("[]");
-                
+
                 var commands = traditionalClient.GetCommands(mockid).ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands")
                     .WithVerb(HttpMethod.Get)
@@ -1129,7 +1243,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("[{\"$schema\": \"http://json-schema.org/schema#\",",
@@ -1146,7 +1260,7 @@ namespace Tests
                     "\"items\": [],",
                     "\"minItems\": 0,",
                     "\"maxItems\": 0 }]"));
-                
+
                 var commands = traditionalClient.GetCommands(mockid).ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands")
                     .WithVerb(HttpMethod.Get)
@@ -1165,7 +1279,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("[{\"$schema\": \"http://json-schema.org/schema#\",",
@@ -1179,7 +1293,7 @@ namespace Tests
                         "}],",
                     "\"minItems\": 1,",
                     "\"maxItems\": 1 }]"));
-                
+
                 var commands = traditionalClient.GetCommands(mockid).ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands")
                     .WithVerb(HttpMethod.Get)
@@ -1205,7 +1319,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("[{\"$schema\": \"http://json-schema.org/schema#\",",
@@ -1220,7 +1334,7 @@ namespace Tests
                         "}],",
                     "\"minItems\": 1,",
                     "\"maxItems\": 1 }]"));
-                
+
                 var commands = traditionalClient.GetCommands(mockid).ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands")
                     .WithVerb(HttpMethod.Get)
@@ -1243,7 +1357,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("[{\"$schema\": \"http://json-schema.org/schema#\",",
@@ -1268,7 +1382,7 @@ namespace Tests
                         "}],",
                     "\"minItems\": 3,",
                     "\"maxItems\": 3 }]"));
-                
+
                 var commands = traditionalClient.GetCommands(mockid).ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands")
                     .WithVerb(HttpMethod.Get)
@@ -1303,9 +1417,27 @@ namespace Tests
                 Assert.AreEqual(null, items[2].EnumerationValues);
             }
         }
-        
+
+        [Test]
+        public void TestGetCommandsNullClient()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                try
+                {
+                    var commands = traditionalClient.GetCommands(mockid);
+                    httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/objects/{mockid}/commands");
+                    Assert.AreEqual(null, commands);
+                }
+                catch
+                {
+                    Assert.Fail();
+                }
+            }
+        }
+
         #endregion
-    
+
         #region GetNetworkDevices Tests
 
         [Test]
@@ -1313,7 +1445,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("{",
@@ -1322,7 +1454,7 @@ namespace Tests
                     "\"previous\": null,",
                     "\"items\": [ ],",
                     "\"self\": \"https://hostname/api/V2/networkDevices?page=1&pageSize=200&sort=name\"}"));
-                
+
                 var devices = traditionalClient.GetNetworkDevices().ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices")
                     .WithVerb(HttpMethod.Get)
@@ -1336,7 +1468,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("{",
@@ -1353,19 +1485,19 @@ namespace Tests
                         "\"ipAddress\": \"\"",
                     "}],",
                     "\"self\": \"https://hostname/api/V2/networkDevices?page=1&pageSize=200&sort=name\"}"));
-                
+
                 var devices = traditionalClient.GetNetworkDevices().ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 Assert.AreEqual(1, devices.Count);
                 Assert.AreEqual(mockid, devices[0].Id);
-                Assert.AreEqual("fully:qualified/reference" , devices[0].ItemReference);
-                Assert.AreEqual("name" , devices[0].Name);
-                Assert.AreEqual("https://hostname/api/v2/enumSets/508/members/197" , devices[0].TypeUrl);
-                Assert.AreEqual("none" , devices[0].Description);
-                Assert.AreEqual("4.0.0.1105" , devices[0].FirmwareVersion);
-                Assert.AreEqual("" , devices[0].IpAddress);
+                Assert.AreEqual("fully:qualified/reference", devices[0].ItemReference);
+                Assert.AreEqual("name", devices[0].Name);
+                Assert.AreEqual("https://hostname/api/v2/enumSets/508/members/197", devices[0].TypeUrl);
+                Assert.AreEqual("none", devices[0].Description);
+                Assert.AreEqual("4.0.0.1105", devices[0].FirmwareVersion);
+                Assert.AreEqual("", devices[0].IpAddress);
             }
         }
 
@@ -1374,7 +1506,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("{",
@@ -1414,7 +1546,7 @@ namespace Tests
                         "\"ipAddress\": \"\"",
                     "}],",
                     "\"self\": \"https://hostname/api/V2/networkDevices?page=1&pageSize=2&sort=name\"}"));
-                
+
                 var devices = traditionalClient.GetNetworkDevices().ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices")
                     .WithVerb(HttpMethod.Get)
@@ -1428,7 +1560,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("{",
@@ -1445,19 +1577,19 @@ namespace Tests
                         "\"ipAddress\": \"\"",
                     "}],",
                     "\"self\": \"https://hostname/api/V2/networkDevices?page=1&pageSize=200&sort=name\"}"));
-                
+
                 var devices = traditionalClient.GetNetworkDevices("197").ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
                 Assert.AreEqual(1, devices.Count);
                 Assert.AreEqual(mockid, devices[0].Id);
-                Assert.AreEqual("fully:qualified/reference" , devices[0].ItemReference);
-                Assert.AreEqual("name" , devices[0].Name);
-                Assert.AreEqual("https://hostname/api/v2/enumSets/508/members/197" , devices[0].TypeUrl);
-                Assert.AreEqual("none" , devices[0].Description);
-                Assert.AreEqual("4.0.0.1105" , devices[0].FirmwareVersion);
-                Assert.AreEqual("" , devices[0].IpAddress);
+                Assert.AreEqual("fully:qualified/reference", devices[0].ItemReference);
+                Assert.AreEqual("name", devices[0].Name);
+                Assert.AreEqual("https://hostname/api/v2/enumSets/508/members/197", devices[0].TypeUrl);
+                Assert.AreEqual("none", devices[0].Description);
+                Assert.AreEqual("4.0.0.1105", devices[0].FirmwareVersion);
+                Assert.AreEqual("", devices[0].IpAddress);
             }
         }
 
@@ -1466,11 +1598,14 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                try {
+                try
+                {
                     var devices = traditionalClient.GetNetworkDevices();
                     httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/networkDevices");
                     Assert.AreEqual(null, devices);
-                } catch {
+                }
+                catch
+                {
                     Assert.Fail();
                 }
             }
@@ -1485,14 +1620,14 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("{",
                     "\"total\": 0,",
                     "\"items\": [ ],",
                     "\"self\": \"https://hostname/api/V2/networkDevices/availableTypes\"}"));
-                
+
                 var types = traditionalClient.GetNetworkDeviceTypes().ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices/availableTypes")
                     .WithVerb(HttpMethod.Get)
@@ -1506,7 +1641,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("{",
@@ -1521,7 +1656,7 @@ namespace Tests
                     "\"description\": \"NAE55-NIE59\",",
                     "\"self\": \"https://hostname/api/V2/enumSets/508/members/185\",",
                     "\"setUrl\": \"https://hostname/api/V2/enumSets/508\"}"));
-                
+
                 var types = traditionalClient.GetNetworkDeviceTypes().ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices/availableTypes")
                     .WithVerb(HttpMethod.Get)
@@ -1540,7 +1675,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("{",
@@ -1556,13 +1691,13 @@ namespace Tests
                     "\"description\": \"NAE55-NIE59\",",
                     "\"self\": \"https://hostname/api/V2/enumSets/508/members/185\",",
                     "\"setUrl\": \"https://hostname/api/V2/enumSets/508\"}"));
-                
+
                 httpTest.RespondWith(string.Concat("{",
                     "\"id\": 195,",
                     "\"description\": \"Field Bus MSTP\",",
                     "\"self\": \"https://hostname/api/V2/enumSets/508/members/195\",",
                     "\"setUrl\": \"https://hostname/api/V2/enumSets/508\"}"));
-                
+
                 var types = traditionalClient.GetNetworkDeviceTypes().ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices/availableTypes")
                     .WithVerb(HttpMethod.Get)
@@ -1587,7 +1722,7 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                httpTest.RespondWithJson(new { accessToken = "faketoken", expires = "2030-01-01T00:00:00Z" });
                 traditionalClient.TryLogin("username", "password", "hostname");
 
                 httpTest.RespondWith(string.Concat("{",
@@ -1597,7 +1732,7 @@ namespace Tests
                     "}],",
                     "\"self\": \"https://hostname/api/V2/networkDevices/availableTypes\"}"));
                 httpTest.RespondWith("No HTTP resource was found that matches the request URI.", 404);
-                
+
                 var types = traditionalClient.GetNetworkDeviceTypes().ToList();
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/networkDevices/availableTypes")
                     .WithVerb(HttpMethod.Get)
@@ -1614,11 +1749,14 @@ namespace Tests
         {
             using (var httpTest = new HttpTest())
             {
-                try {
+                try
+                {
                     var types = traditionalClient.GetNetworkDeviceTypes();
                     httpTest.ShouldNotHaveCalled($"https://hostname/api/V2/networkDevices/availableTypes");
                     Assert.AreEqual(null, types);
-                } catch {
+                }
+                catch
+                {
                     Assert.Fail();
                 }
             }

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -135,7 +135,7 @@ namespace Tests
                 httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
                 traditionalClient.TryLogin("username", "password", "hostname");
 
-                httpTest.RespondWith(mockid.ToString());
+                httpTest.RespondWith($"\"{mockid.ToString()}\"");
                 var id = traditionalClient.GetObjectIdentifier("fully:qualified/reference");
                 httpTest.ShouldHaveCalled($"https://hostname/api/V2/objectIdentifiers")
                 .WithVerb(HttpMethod.Get)

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -1701,7 +1701,7 @@ namespace Tests
 
         #endregion
 
-        #region GetNetworkDeviceTypes
+        #region GetNetworkDeviceTypes Tests
 
         [Test]
         public void TestGetNetworkDeviceTypesNone()
@@ -1852,7 +1852,7 @@ namespace Tests
 
         #endregion
 
-        #region TestGetObjects
+        #region GetObjects Tests
 
         [Test]
         public void TestGetObjectsNone()

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -589,5 +589,133 @@ namespace Tests
                 Assert.AreEqual(results.Count(), 0);
             }
         }
+
+        [Test]
+        public void TestWritePropertyString()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("Accepted", 202);
+
+                traditionalClient.WriteProperty(mockid, mockAttributeName, "newValue");
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                    .WithVerb(HttpMethod.Patch)
+                    .Times(1);
+            }
+        }
+
+        [Test]
+        public void TestWritePropertyInteger()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("Accepted", 202);
+
+                traditionalClient.WriteProperty(mockid, mockAttributeName, 32);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                    .WithVerb(HttpMethod.Patch)
+                    .Times(1);
+            }
+        }
+
+        [Test]
+        public void TestWritePropertyFloat()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("Accepted", 202);
+
+                traditionalClient.WriteProperty(mockid, mockAttributeName, 32.5);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                    .WithVerb(HttpMethod.Patch)
+                    .Times(1);
+            }
+        }
+
+        [Test]
+        public void TestWritePropertyBoolean()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("Accepted", 202);
+
+                traditionalClient.WriteProperty(mockid, mockAttributeName, true);
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                    .WithVerb(HttpMethod.Patch)
+                    .Times(1);
+            }
+        }
+
+        [Test]
+        public void TestWritePropertyArrayString()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("Accepted", 202);
+
+                traditionalClient.WriteProperty(mockid, mockAttributeName, new [] { "1", "2", "3" });
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                    .WithVerb(HttpMethod.Patch)
+                    .Times(1);
+            }
+        }
+
+        [Test]
+        public void TestWritePropertyArrayInteger()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("Accepted", 202);
+
+                traditionalClient.WriteProperty(mockid, mockAttributeName, new [] { 1, 2, 3 });
+
+                httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                    .WithVerb(HttpMethod.Patch)
+                    .Times(1);
+            }
+        }
+
+        [Test]
+        public void TestWritePropertyBadRequestThrowsException()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWithJson(new {accessToken = "faketoken", expires = "2030-01-01T00:00:00Z"});
+                var traditionalClient = new TraditionalClient("username", "password", "hostname", 2);
+
+                httpTest.RespondWith("Bad Request", 400);
+                try {
+                    traditionalClient.WriteProperty(mockid, mockAttributeName, "badType");
+                    Assert.Fail();
+                } catch {
+                    httpTest.ShouldHaveCalled($"https://hostname/api/v2/objects/{mockid}")
+                        .WithVerb(HttpMethod.Patch)
+                        .Times(1);
+                }
+            }
+        }
     }
 }

--- a/basic-services.Tests/TraditionalClientTests.cs
+++ b/basic-services.Tests/TraditionalClientTests.cs
@@ -180,6 +180,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(1, result.NumericValue);
                 Assert.AreEqual("1", result.StringValue);
+                Assert.AreEqual(true, result.BooleanValue);
                 Assert.AreEqual(null, result.ArrayValue);
                 Assert.AreEqual(null, result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
@@ -203,6 +204,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(1.1, result.NumericValue);
                 Assert.AreEqual("1.1", result.StringValue);
+                Assert.AreEqual(true, result.BooleanValue);
                 Assert.AreEqual(null, result.ArrayValue);
                 Assert.AreEqual(null, result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
@@ -226,6 +228,7 @@ namespace Tests
                     .Times(1);                
                 Assert.AreEqual(0, result.NumericValue);
                 Assert.AreEqual("stringvalue", result.StringValue);
+                Assert.AreEqual(false, result.BooleanValue);
                 Assert.AreEqual(null, result.ArrayValue);
                 Assert.AreEqual(null, result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
@@ -249,6 +252,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(1, result.NumericValue);
                 Assert.AreEqual("True", result.StringValue);
+                Assert.AreEqual(true, result.BooleanValue);
                 Assert.AreEqual(null, result.ArrayValue);                
                 Assert.AreEqual(null, result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
@@ -272,6 +276,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(0, result.NumericValue);
                 Assert.AreEqual("False", result.StringValue);
+                Assert.AreEqual(false, result.BooleanValue);
                 Assert.AreEqual(null, result.ArrayValue);                
                 Assert.AreEqual(null, result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
@@ -296,6 +301,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(60, result.NumericValue);
                 Assert.AreEqual("60", result.StringValue);
+                Assert.AreEqual(true, result.BooleanValue);
                 Assert.AreEqual(null, result.ArrayValue);
                 Assert.AreEqual("writePriorityEnumSet.priorityNone", result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
@@ -320,6 +326,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(0, result.NumericValue);
                 Assert.AreEqual("stringvalue", result.StringValue);
+                Assert.AreEqual(false, result.BooleanValue);
                 Assert.AreEqual(null, result.ArrayValue);
                 Assert.AreEqual("writePriorityEnumSet.priorityNone", result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);
@@ -345,6 +352,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(0, result.NumericValue);
                 Assert.AreEqual("stringvalue", result.StringValue);
+                Assert.AreEqual(false, result.BooleanValue);
                 Assert.AreEqual(null, result.ArrayValue);
                 Assert.AreEqual("writePriorityEnumSet.priorityDefault", result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.noInput", result.Reliability);
@@ -369,6 +377,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(0, result.NumericValue);
                 Assert.AreEqual("Array", result.StringValue);
+                Assert.AreEqual(false, result.BooleanValue);
                 Assert.AreEqual(("1", 1, true), result.ArrayValue[0]);
                 Assert.AreEqual(("2", 2, true), result.ArrayValue[1]);
                 Assert.AreEqual(null, result.Priority);
@@ -394,6 +403,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(0, result.NumericValue);
                 Assert.AreEqual("Array", result.StringValue);
+                Assert.AreEqual(false, result.BooleanValue);
                 Assert.AreEqual(("stringvalue1", 0, false), result.ArrayValue[0]);
                 Assert.AreEqual(("stringvalue2", 0, false), result.ArrayValue[1]);
                 Assert.AreEqual(null, result.Priority);
@@ -420,6 +430,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(0, result.NumericValue);
                 Assert.AreEqual("Array", result.StringValue);
+                Assert.AreEqual(false, result.BooleanValue);
                 Assert.AreEqual(("Unsupported Data Type", 1, false), result.ArrayValue[0]);
                 Assert.AreEqual(("Unsupported Data Type", 1, false), result.ArrayValue[1]);
                 Assert.AreEqual(null, result.Priority);
@@ -464,6 +475,7 @@ namespace Tests
                     .Times(1);
                 Assert.AreEqual(1, result.NumericValue);
                 Assert.AreEqual("Unsupported Data Type", result.StringValue);
+                Assert.AreEqual(false, result.BooleanValue);
                 Assert.AreEqual(null, result.ArrayValue);
                 Assert.AreEqual(null, result.Priority);
                 Assert.AreEqual("reliabilityEnumSet.reliable", result.Reliability);

--- a/basic-services.Tests/basic-services.Tests.csproj
+++ b/basic-services.Tests/basic-services.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Flurl" Version="2.8.2" />
+    <PackageReference Include="Flurl.Http" Version="2.4.2" />
+    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="basic-services">
+      <HintPath>..\basic-services\bin\Debug\netstandard2.0\basic-services.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/basic-services/ApiVersion.cs
+++ b/basic-services/ApiVersion.cs
@@ -1,0 +1,7 @@
+namespace JohnsonControls.Metasys.BasicServices
+{
+    public enum ApiVersion
+    {
+        V2
+    }
+}

--- a/basic-services/Command.cs
+++ b/basic-services/Command.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace JohnsonControls.Metasys.BasicServices
+{
+    public struct Command
+    {
+        private CultureInfo _CultureInfo;
+
+        // Translate if specified culture is not US_en
+        public string Title { private set; get; }
+
+        public string CommandId { private set; get; }
+
+        public IEnumerable<Item> Items { private set; get; }
+
+        public struct Item
+        {
+            public string Title;
+
+            // If the Item is a constant this should be "const" otherwise the type specified
+            public string Type;
+
+            // Null unless Type is "const"
+            public IEnumerable<EnumerationItem> EnumerationValues;
+
+            // If type is not number this value is 1
+            public double Minimum;
+
+            // If type is not number this value is 1
+            public double Maximum;
+
+            internal Item(string title, string type, double minimum = 1, double maximum = 1, IEnumerable<EnumerationItem> enums = null)
+            {
+                Title = title;
+                Type = type;
+                Minimum = minimum;
+                Maximum = maximum;
+                EnumerationValues = enums;
+            }
+        }
+
+        public struct EnumerationItem
+        {
+            public string Title;
+
+            public string Value;
+
+            internal EnumerationItem(string title, string value)
+            {
+                Title = title;
+                Value = value;
+            }
+        }
+
+        internal Command(JToken token, CultureInfo cultureInfo = null)
+        {
+            _CultureInfo = cultureInfo;
+            Title = token["title"].Value<string>();
+            CommandId = token["commandId"].Value<string>();
+            Items = null;
+            List<Item> itemsList = new List<Item>();
+
+            var items = token["items"] as JArray;
+            if (items != null && items.Count > 0)
+            {
+                foreach (var item in items)
+                {
+                    // Check if a value or an enum
+                    var enumSet = item["oneOf"] as JArray;
+                    if (enumSet == null)
+                    {
+                        string title = item["title"].Value<string>();
+                        string type = item["type"].Value<string>();
+                        double maximum = item["maximum"].Value<double>();
+                        double minimum = item["minimum"].Value<double>();
+                        itemsList.Add(new Item(title, type, minimum, maximum));
+                    }
+                    else
+                    {
+                        List<EnumerationItem> enumList = new List<EnumerationItem>();
+
+                        foreach (var e in enumSet)
+                        {
+                            string eTitle = e["title"].Value<string>();
+                            string eValue = e["const"].Value<string>();
+                            enumList.Add(new EnumerationItem(eTitle, eValue));
+                        }
+                        itemsList.Add(new Item("oneOf", "enum", 1, 1, enumList));
+                    }
+                }
+                Items = itemsList;
+            }
+        }
+
+        public override string ToString()
+        {
+            string str = string.Concat("Title: ", Title, "\nCommandId: ", CommandId, "\nItems: ");
+            if (Items != null) {
+                foreach (var item in Items)
+                {
+                    str = string.Concat(str, "\n\n  Title: ", item.Title, "\n  Type: ", item.Type);
+                    if (item.EnumerationValues != null)
+                    {
+                        str = string.Concat(str, "\n  Items: ");
+                        foreach (var value in item.EnumerationValues)
+                        {
+                            str = string.Concat(str, "\n\n    Title: ", value.Title, "\n    Value: ", value.Value);
+                        }
+                    }
+                    else
+                    {
+                        str = string.Concat(str, "\n  Maximum: ", item.Maximum, "\n  Minimum: ", item.Minimum);
+                    }
+                }
+                str = string.Concat(str, "\n");
+            }
+             
+            return str;
+        }
+    }
+}

--- a/basic-services/MetasysObject.cs
+++ b/basic-services/MetasysObject.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace JohnsonControls.Metasys.BasicServices
+{
+    public struct MetasysObject
+    {
+        private CultureInfo _CultureInfo;
+
+        public string ItemReference { private set; get; }
+
+        public Guid Id { private set; get; }
+
+        public string Name { private set; get; }
+
+        public string Type { private set; get; }
+
+        internal MetasysObject(JToken token, string type = "", CultureInfo cultureInfo = null)
+        {
+            _CultureInfo = cultureInfo;
+            Type = type;
+            
+            try
+            {
+                Id = new Guid(token["id"].Value<string>());
+            }
+            catch
+            {
+                Id = Guid.Empty;
+            }
+
+            string placeholder = "";
+            try
+            {
+                ItemReference = token["itemReference"].Value<string>();
+            }
+            catch
+            {
+                ItemReference = placeholder;
+            }
+
+            try
+            {
+                Name = token["name"].Value<string>();
+            }
+            catch
+            {
+                Name = placeholder;
+            }
+        }
+    }
+}

--- a/basic-services/NetworkDevice.cs
+++ b/basic-services/NetworkDevice.cs
@@ -16,7 +16,7 @@ namespace JohnsonControls.Metasys.BasicServices
 
         public string Name { private set; get; }
 
-        public string TypeUrl { private set; get; }
+        public string Type { private set; get; }
 
         public string Description { private set; get; }
 
@@ -24,9 +24,11 @@ namespace JohnsonControls.Metasys.BasicServices
 
         public string IpAddress { private set; get; }
 
-        internal NetworkDevice(JToken token, CultureInfo cultureInfo = null)
+        internal NetworkDevice(JToken token, string type = "", CultureInfo cultureInfo = null)
         {
             _CultureInfo = cultureInfo;
+            Type = type;
+            
             try
             {
                 Id = new Guid(token["id"].Value<string>());
@@ -36,7 +38,7 @@ namespace JohnsonControls.Metasys.BasicServices
                 Id = Guid.Empty;
             }
 
-            string placeholder = "N/A";
+            string placeholder = "";
             try
             {
                 ItemReference = token["itemReference"].Value<string>();
@@ -53,15 +55,6 @@ namespace JohnsonControls.Metasys.BasicServices
             catch
             {
                 Name = placeholder;
-            }
-
-            try
-            {
-                TypeUrl = token["typeUrl"].Value<string>();
-            }
-            catch
-            {
-                TypeUrl = placeholder;
             }
 
             try

--- a/basic-services/NetworkDevice.cs
+++ b/basic-services/NetworkDevice.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace JohnsonControls.Metasys.BasicServices
+{
+    public struct NetworkDevice
+    {
+        private CultureInfo _CultureInfo;
+
+        public string ItemReference { private set; get; }
+
+        public Guid Id { private set; get; }
+
+        public string Name { private set; get; }
+
+        public string TypeUrl { private set; get; }
+
+        public string Description { private set; get; }
+
+        public string FirmwareVersion { private set; get; }
+
+        public string IpAddress { private set; get; }
+
+        internal NetworkDevice(JToken token, CultureInfo cultureInfo = null)
+        {
+            _CultureInfo = cultureInfo;
+            try
+            {
+                Id = new Guid(token["id"].Value<string>());
+            }
+            catch
+            {
+                Id = Guid.Empty;
+            }
+
+            string placeholder = "N/A";
+            try
+            {
+                ItemReference = token["itemReference"].Value<string>();
+            }
+            catch
+            {
+                ItemReference = placeholder;
+            }
+
+            try
+            {
+                Name = token["name"].Value<string>();
+            }
+            catch
+            {
+                Name = placeholder;
+            }
+
+            try
+            {
+                TypeUrl = token["typeUrl"].Value<string>();
+            }
+            catch
+            {
+                TypeUrl = placeholder;
+            }
+
+            try
+            {
+                Description = token["description"].Value<string>();
+            }
+            catch
+            {
+                Description = placeholder;
+            }
+
+            try
+            {
+                FirmwareVersion = token["firmwareVersion"].Value<string>();
+            }
+            catch
+            {
+                FirmwareVersion = placeholder;
+            }
+
+            try
+            {
+                IpAddress = token["ipAddress"].Value<string>();
+            }
+            catch
+            {
+                IpAddress = placeholder;
+            }
+        }
+    }
+}

--- a/basic-services/README.md
+++ b/basic-services/README.md
@@ -1,0 +1,176 @@
+Metasys Basic Services
+====================
+
+This project provides a library for accessing the most
+common services of the Metasys Server API.
+
+The intent is to provide an API that is very similar to the
+original MSSDA (Metasys System Secure Data Access) library.
+
+Package name and even org name can still be changed at this time. Suggestions welcome.
+
+
+Installation
+------
+
+Not implemented yet. This is an illustration of desired installation.
+
+
+For dotnet app you can install and use like this:
+
+```bash
+$ dotnet new console
+$ nuget install metasys-basic-services
+```
+
+For Excel App (or any other COM app)
+
+We need a way to install the dll(s) and then also register
+them with COM system.
+
+```bash
+$ nuget install metasys-basic-services
+./register
+```
+
+This approach needs some investigation
+
+1. I assume nuget packages can just be installed "anywhere"? Typically they would be added to some existing
+   dotnet project. But in this case we just need the dll's installed somewhere on box
+2. Need some direction on where they should be installed. Some guidance for the Excel app developer as to what will happen
+3. Guidance on switching to the correct path and then running the ./register script
+4. Guidance on how to add a reference to the dll from excel
+
+Usage
+-------
+
+The following is just some psuedocode. Note, we'll need a resource manager and resource files (work already begun) 
+to provide translations for enums (even for English). 
+
+```csharp
+// Login
+var client = new TraditionalClient();
+
+// apiversion will always have a default based on the release of basic-services, like this initial version will 
+// default to v2. The next major version (released with Metasys 11.0 will likely default to v3)
+// If you need to access both versions then instantiate two clients.
+client.Login(username, password, hostname, apiversion) 
+
+// Read an analog value
+var result = client.ReadProperty(guid, "presentValue")
+Console.Log(result.NumericValue)
+
+// Read an enum value
+var result = client.ReadProperty(guid2, "presentValue")
+var enumValue = result.StringValue
+Console.Log(resourceManger.GetString(enumValue, "en-US")
+
+// Read a string value
+var result = client.ReadProperty(guid3, "description")
+Console.Log(result.StringValue)
+
+// Read a boolean value
+var result = client.ReadProperty(guid4, "isEnabled")
+Console.Log(result.StringValue) // prints "True" or "False" 
+Console.Log(result.NumericValue) // prints 1 or 0
+Console.Log(result.BooleanValue) // prints "True" or "False". This BooleanValue isn't in scope but perhaps it should be
+
+// Read an array value, new for basic services, didn't exist in MSSDA
+var result = client.ReadProperty(guid5, "ipAddress") // ipAddress is an array of bytes
+var firstByteResult = result.ArrayValue
+Console.Log(firstByteResult.Item1)   // prints "192" as Item1 is the string representation
+
+// alternatively
+var (string StringValue, double NumericValue) result = client.ReadProperty(guid5, "ipAddress") // ipAddress is an array of bytes
+Console.Log(result.StringValue)
+
+```
+
+
+Requirements
+-----------
+
+This project will have several small phases. The first phase will
+expose add reading of objects/attributes. The second phase will writing and commanding.
+The final phase will add discover of devices and objects.
+
+* The project must maintain a CHANGELOG (https://keepachangelog.com/en/1.0.0/).I have example here: https://github.com/metasys-server/nodekit/blob/master/CHANGELOG.md 
+* This package must be published in the metasys organization at nuget.org with appropriate semantic versioning, https://semver.org
+copyright, licensing, link to github repo, etc. 
+
+* We will release a version at the end of Phase 1. Most likely 1.0. Earlier versions can be published but only as 0.x versions
+or as pre-release versions of 1.0 (follow microsoft guidance here on prerelease versioning: https://docs.microsoft.com/en-us/nuget/create-packages/prerelease-packages )
+    Breaking changes should align with major versions of Metasys where possible. We should avoid any breaking changes
+    in between release of Metasys.
+    
+* Naming guidelines: Follow Microsoft Naming guidelines https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-guidelines 
+
+* All submitted code must be reviewed through pull requests.
+
+* Good commit messages must be used on all commits. https://chris.beams.io/posts/git-commit/ 
+Most commits should NOT be one liners. When adding a commit add a paragraph or a few paragraphs explaining what you did.
+Only the smallest of commits should be one line messages.
+
+* Consider adding a light weight CONTRIBUTING.md or referencing Microsoft's for guidance for outsiders and others in JCI.
+
+* Track the Issues on this repo and provide guidance (where possible) on roadmap.
+
+### Phase 1
+
+We will begin on what I'm calling the TraditionalClient. (name can be changed).
+I'm calling it the TraditionalClient because of its heavy influence on the old MSSDA.
+The traditional client is probably ideal for the typical MSSDA customer because it 
+doesn't utilize many advanced C# features. But it is non-ideal for advanced development.
+
+1. It is synchronous. A more advanced SDK would expose all operations as asynch operations.
+2. It doesn't use generics. Instead it returns simple return structures (like ReadPropertyResult) that
+   model attribute values as strings, numbers and array. The client just needs to know based on what
+   attribute they are reading which of the values is most appropriate for thier usage. This is how 
+   MSSDA worked as well. A more advanced SDK would use `JToken` values or `dynamic` or generics.
+3. It doesn't use Nullable<T> which makes it a little awkward in some cases. Like what is the numeric value
+   of the string "AV1"? Using the MSSDA guidelines the numeric value of a string will be 0. (A more sophisticated
+   API would mark the numeric value as nullable for when it doesn't make sense)
+   
+The following requirements will be met in phase 1:
+
+1. Implement Login
+1. Implement GetObjectIdentifier
+1. Implement ReadProperty
+2. Implement ReadPropertyMultiple
+3. Expose the library as COM dll for use in Excel apps
+4. Ensure signatures of the methods are easy to consume via COM
+5. Must provide client side resource files for translating enum values
+   coming back from the server. (Unlike MSSDA, enums are not returned
+   from the server as localized strings. They are returned as "symbolic
+   strings" which are more useful at the API level. The client side
+   resource files will provide the ability for clients to show localized
+   strings.
+6. Nuget package support (for deployment to metasys-server org)
+7. Script for registering dll for COM (would only be used by Excel apps, wouldn't be needed for .Net apps)
+
+Suppoted Data Types
+
+boolean, numbers, strings, enums, arrays of one of these.
+
+Not supported: date, time, listOf, structs, object identifiers, bits, etc.
+
+### Phase 2
+
+Allow for reverse lookup of resource file. Given a localized string,
+find the enum value associated (for usage in SendCommand and WriteProperty)
+
+2. Implement WriteProperty
+4. Implement WritePropertyMultiple
+5. Implement GetCommands
+5. Implement SendCommand
+
+
+### Phase 3
+
+1. Implement GetObjectList() this will differ from MSSDA. MSSDA returned just the immediate children of given object.
+   10.1 Metasys Server has the /objects endpoint which allows you to specify a parent object and ask for children `/objects/{id}/objects`
+   but it'll return all children. And the result will be paged. So we can decide if GetObjectList should fetch all pages.
+   Probably it should. (Future release we could add support for paging in client)
+   
+2. Implement GetDeviceList() this will likely differ from MSSDA as well. We have the /networkDevices endpoint which will
+   be the source of data. 

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -77,10 +77,16 @@ namespace JohnsonControls.Metasys.BasicServices
                     NumericValue = 0;
                     StringValue = "Array";
                     break;
-                // case JTokenType.Boolean:
-                //     // todo
-                //     ArrayValue = null;
-                //     break;
+                case JTokenType.Boolean:
+                    if ((bool)(token) == true) {
+                        NumericValue = 1;
+                        StringValue = "True";
+                    } else {
+                        NumericValue = 0;
+                        StringValue = "False";
+                    }
+                    ArrayValue = null;
+                    break;
                 default:
                     NumericValue = 1;
                     StringValue = "Unsupported Data Type";

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -22,12 +22,15 @@ namespace JohnsonControls.Metasys.BasicServices
         
         public string Attribute { private set; get; }
 
+        public Guid Id { private set; get; }
+
         public string Reliability { private set; get; }
         public string Priority { private set; get; }
         public bool IsReliable => Reliability == "reliabilityEnumSet.reliable";
 
-        internal ReadPropertyResult(JToken token, string attribute, string reliability = null, string priority = null)
+        internal ReadPropertyResult(Guid id, JToken token, string attribute, string reliability = null, string priority = null)
         {
+            Id = id;
             Attribute = attribute;
             Reliability = reliability;
             Priority = priority;

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -20,20 +20,30 @@ namespace JohnsonControls.Metasys.BasicServices
         // This will be null for non-array data types.
         public (string, double)[] ArrayValue { private set; get; }
         
-        
+        public string Attribute { private set; get; }
+
         public string Reliability { private set; get; }
         public string Priority { private set; get; }
         public bool IsReliable => Reliability == "reliabilityEnumSet.reliable";
 
-        internal ReadPropertyResult(JToken token, string reliability = null, string priority = null)
+        internal ReadPropertyResult(JToken token, string attribute, string reliability = null, string priority = null)
         {
+            Attribute = attribute;
             Reliability = reliability;
             Priority = priority;
+            StringValue = null;
+            NumericValue = 1;
+            ArrayValue = null;
 
+            ReadToken(token);
+        }
+
+        /// <summary>Parses the JToken type and assigns struct values appropriately.</summary>
+        internal void ReadToken(JToken token)
+        {
             if (token == null) {
                 NumericValue = 1;
                 StringValue = "Unsupported Data Type";
-                ArrayValue = null;
                 return;
             }
             // switch on token type and set the fields appropriately
@@ -42,46 +52,17 @@ namespace JohnsonControls.Metasys.BasicServices
                 case JTokenType.Integer:
                     NumericValue = (double) token.Value<double>();
                     StringValue = NumericValue.ToString();
-                    ArrayValue = null;
                     break;
                 case JTokenType.Float:
                     NumericValue = (double) token.Value<double>();
                     StringValue = NumericValue.ToString();
-                    ArrayValue = null;
                     break;
                 case JTokenType.String:
                     NumericValue = 0;
                     StringValue = (string) token.Value<string>();
-                    ArrayValue = null;
                     break;
                 case JTokenType.Array:
-                    JArray arr = JArray.Parse(token.ToString());
-                    ArrayValue = new (string, double)[arr.Count];
-                    int index = 0;
-                    foreach(var item in arr.Children())
-                    {
-                        double value = 0;
-                        switch (item.Type)
-                        {
-                            case JTokenType.Integer:
-                                value = (double) item.Value<double>();
-                                ArrayValue[index] = (value.ToString(), value);
-                                break;
-                            case JTokenType.Float:
-                                value = (double) item.Value<double>();
-                                ArrayValue[index] = (value.ToString(), value);
-                                break;
-                            case JTokenType.String:
-                                ArrayValue[index] = ((string) item.Value<string>(), value);
-                                break;
-                            default:
-                                ArrayValue[index] = ("Unsupported Data Type", 1);
-                                break;
-                        }
-                        index++;
-                    }
-                    NumericValue = 0;
-                    StringValue = "Array";
+                    ReadArray(token);
                     break;
                 case JTokenType.Boolean:
                     if ((bool)(token) == true) {
@@ -91,14 +72,74 @@ namespace JohnsonControls.Metasys.BasicServices
                         NumericValue = 0;
                         StringValue = "False";
                     }
-                    ArrayValue = null;
+                    break;
+                case JTokenType.Object:
+                    ReadObject(token);
                     break;
                 default:
                     NumericValue = 1;
                     StringValue = "Unsupported Data Type";
-                    ArrayValue = null;
                     break;
             }
+        }
+
+        /// <summary>Parses a JArray and adds (string, double) pairs to an array based on JToken type.</summary>
+        internal void ReadArray(JToken token) {
+            JArray arr = JArray.Parse(token.ToString());
+            ArrayValue = new (string, double)[arr.Count];
+            int index = 0;
+            foreach(var item in arr.Children())
+            {
+                double value = 0;
+                switch (item.Type)
+                {
+                    case JTokenType.Integer:
+                        value = (double) item.Value<double>();
+                        ArrayValue[index] = (value.ToString(), value);
+                        break;
+                    case JTokenType.Float:
+                        value = (double) item.Value<double>();
+                        ArrayValue[index] = (value.ToString(), value);
+                        break;
+                    case JTokenType.String:
+                        ArrayValue[index] = ((string) item.Value<string>(), value);
+                        break;
+                    default:
+                        ArrayValue[index] = ("Unsupported Data Type", 1);
+                        break;
+                }
+                index++;
+            }
+            NumericValue = 0;
+            StringValue = "Array";
+        }
+
+        /// <summary>Searches the JObject for reliability and priority fields and finds a value to use.</summary>
+        internal void ReadObject(JToken token) {
+            JToken valueToken = token["value"];
+            JToken reliabilityToken = token["reliability"];
+            JToken priorityToken = token["priority"];
+
+            if (reliabilityToken != null) 
+            {
+                Reliability = reliabilityToken.ToString();
+            }
+            if (priorityToken != null)
+            {
+                Priority = priorityToken.ToString();
+            }
+            if (valueToken == null) {
+                // Search for the first value to use as the value (there could exist more than 1)
+                JObject obj = JObject.Parse(token.ToString());
+                foreach (JProperty property in obj.Properties())
+                {
+                    if (!property.Name.Equals("reliability") && !property.Name.Equals("priority")) {
+                        valueToken = property.Value;
+                        break;
+                    }
+                }
+            }
+            ReadToken(valueToken);
         }
     }
 }

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -4,8 +4,6 @@ using Newtonsoft.Json.Linq;
 
 namespace JohnsonControls.Metasys.BasicServices
 {
-
-
     public struct ReadPropertyResult
     {
         // Follow rules for stringValue in MSSDA Bulletin, with the following
@@ -31,6 +29,9 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             Reliability = reliability;
             Priority = priority;
+            NumericValue = 0;
+            StringValue = NumericValue.ToString();
+            ArrayValue = null;
             
             // switch on token type and set the fields appropriately
             switch (token.Type)
@@ -39,10 +40,9 @@ namespace JohnsonControls.Metasys.BasicServices
                     NumericValue = (double) token.Value<double>();
                     StringValue = NumericValue.ToString();
                     ArrayValue = null;
-
                     break;
                 case JTokenType.Float:
-                    //todo
+                    // todo
                     break;
                 case JTokenType.String:
                     // todo
@@ -54,15 +54,9 @@ namespace JohnsonControls.Metasys.BasicServices
                     // todo
                     break;
                 default:
-                    //todo
+                    // todo
                     break;
             }
-            
         }
-
     }
-
-    
-
-
 }

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Linq;
 
 namespace JohnsonControls.Metasys.BasicServices
 {
-    public struct ReadPropertyResult
+    public class ReadPropertyResult
     {
         private const string Reliable = "reliabilityEnumSet.reliable";
 

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Linq;
 
 namespace JohnsonControls.Metasys.BasicServices
 {
-    public class ReadPropertyResult
+    public struct ReadPropertyResult
     {
         private const string Reliable = "reliabilityEnumSet.reliable";
 

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -90,9 +90,11 @@ namespace JohnsonControls.Metasys.BasicServices
                     if ((bool)(token) == true) {
                         NumericValue = 1;
                         StringValue = "True";
+                        BooleanValue = true;
                     } else {
                         NumericValue = 0;
                         StringValue = "False";
+                        BooleanValue = false;
                     }
                     break;
                 case JTokenType.Object:

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -126,7 +126,7 @@ namespace JohnsonControls.Metasys.BasicServices
                         ArrayValue[index] = (value.ToString(), value, Convert.ToBoolean(NumericValue));
                         break;
                     case JTokenType.String:
-                        ArrayValue[index] = ((string) item.Value<string>(), value, false);
+                        ArrayValue[index] = (item.Value<string>(), value, false);
                         break;
                     default:
                         ArrayValue[index] = ("Unsupported Data Type", 1, false);

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -48,10 +48,35 @@ namespace JohnsonControls.Metasys.BasicServices
                     StringValue = (string) token.Value<string>();
                     ArrayValue = null;
                     break;
-                // case JTokenType.Array:
-                //     // todo
-                //     NumericValue = 0;
-                //     break;
+                case JTokenType.Array:
+                    JArray arr = JArray.Parse(token.ToString());
+                    ArrayValue = new (string, double)[arr.Count];
+                    int index = 0;
+                    foreach(var item in arr.Children())
+                    {
+                        double value = 0;
+                        switch (item.Type)
+                        {
+                            case JTokenType.Integer:
+                                value = (double) item.Value<double>();
+                                ArrayValue[index] = (value.ToString(), value);
+                                break;
+                            case JTokenType.Float:
+                                value = (double) item.Value<double>();
+                                ArrayValue[index] = (value.ToString(), value);
+                                break;
+                            case JTokenType.String:
+                                ArrayValue[index] = ((string) item.Value<string>(), value);
+                                break;
+                            default:
+                                ArrayValue[index] = ("Unsupported Data Type", 1);
+                                break;
+                        }
+                        index++;
+                    }
+                    NumericValue = 0;
+                    StringValue = "Array";
+                    break;
                 // case JTokenType.Boolean:
                 //     // todo
                 //     ArrayValue = null;

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -29,9 +29,6 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             Reliability = reliability;
             Priority = priority;
-            NumericValue = 0;
-            StringValue = NumericValue.ToString();
-            ArrayValue = null;
             
             // switch on token type and set the fields appropriately
             switch (token.Type)
@@ -42,19 +39,27 @@ namespace JohnsonControls.Metasys.BasicServices
                     ArrayValue = null;
                     break;
                 case JTokenType.Float:
-                    // todo
+                    NumericValue = (double) token.Value<double>();
+                    StringValue = NumericValue.ToString();
+                    ArrayValue = null;
                     break;
                 case JTokenType.String:
-                    // todo
+                    NumericValue = 0;
+                    StringValue = (string) token.Value<string>();
+                    ArrayValue = null;
                     break;
-                case JTokenType.Array:
-                    // todo
-                    break;
-                case JTokenType.Boolean:
-                    // todo
-                    break;
+                // case JTokenType.Array:
+                //     // todo
+                //     NumericValue = 0;
+                //     break;
+                // case JTokenType.Boolean:
+                //     // todo
+                //     ArrayValue = null;
+                //     break;
                 default:
-                    // todo
+                    NumericValue = 1;
+                    StringValue = "Unsupported Data Type";
+                    ArrayValue = null;
                     break;
             }
         }

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -1,0 +1,68 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+
+namespace JohnsonControls.Metasys.BasicServices
+{
+
+
+    public struct ReadPropertyResult
+    {
+        // Follow rules for stringValue in MSSDA Bulletin, with the following
+        // addendum. The string value for an Array will be "Array".
+        public string StringValue { private set; get; }
+        
+        // Follow rules for rawValue in MSSDA Bulletin, with the following 
+        // addendum. The numeric value for an Array will be 0
+        // Enums will also be 0 (since we don't expose their numbers, we just expose them as strings)
+        public double NumericValue { private set; get; }
+        
+        // This is new. MSSDA required you to read just one element of an array.
+        // We will support reading the entire array (asusming it's an array of primitives)
+        // This will be null for non-array data types.
+        public (string, double)[] ArrayValue { private set; get; }
+        
+        
+        public string Reliability { private set; get; }
+        public string Priority { private set; get; }
+        public bool IsReliable => Reliability == "reliabilityEnumSet.reliable";
+
+        internal ReadPropertyResult(JToken token, string reliability = null, string priority = null)
+        {
+            Reliability = reliability;
+            Priority = priority;
+            
+            // switch on token type and set the fields appropriately
+            switch (token.Type)
+            {
+                case JTokenType.Integer:
+                    NumericValue = (double) token.Value<double>();
+                    StringValue = NumericValue.ToString();
+                    ArrayValue = null;
+
+                    break;
+                case JTokenType.Float:
+                    //todo
+                    break;
+                case JTokenType.String:
+                    // todo
+                    break;
+                case JTokenType.Array:
+                    // todo
+                    break;
+                case JTokenType.Boolean:
+                    // todo
+                    break;
+                default:
+                    //todo
+                    break;
+            }
+            
+        }
+
+    }
+
+    
+
+
+}

--- a/basic-services/ReadPropertyResult.cs
+++ b/basic-services/ReadPropertyResult.cs
@@ -29,7 +29,13 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             Reliability = reliability;
             Priority = priority;
-            
+
+            if (token == null) {
+                NumericValue = 1;
+                StringValue = "Unsupported Data Type";
+                ArrayValue = null;
+                return;
+            }
             // switch on token type and set the fields appropriately
             switch (token.Type)
             {

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -158,6 +158,8 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Read many attribute values given the Guids of the objects.
         /// </summary>
+        /// <param name="ids"></param>
+        /// <param name="attributeNames"></param>
         public IEnumerable<ReadPropertyResult> ReadPropertyMultiple(IEnumerable<Guid> ids,
             IEnumerable<string> attributeNames)
         {
@@ -178,6 +180,8 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Read many attribute values given the Guids of the objects asynchronously.
         /// </summary>
+        /// <param name="ids"></param>
+        /// <param name="attributeNames"></param>
         private async Task<List<ReadPropertyResult>> ReadPropertyMultipleAsync(IEnumerable<Guid> ids,
             IEnumerable<string> attributeNames)
         {
@@ -212,6 +216,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Read entire object given the Guid of the object asynchronously.
         /// </summary>
+        /// <param name="id"></param>
         /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
         private async Task<(Guid, JToken)> ReadObjectAsync(Guid id)
         {
@@ -273,6 +278,10 @@ namespace JohnsonControls.Metasys.BasicServices
                 return;
             }
 
+            if (ids == null || attributeValues == null) {
+                return;
+            }
+
             Dictionary<string, object> pairs = new Dictionary<string, object>();
             foreach (var attribute in attributeValues)
             {
@@ -300,6 +309,8 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Write many attribute values given the Guids of the objects asynchronously.
         /// </summary>
+        /// <param name="ids"></param>
+        /// <param name="json">The formatted request body</param>
         private async void WritePropertyMultipleAsync(IEnumerable<Guid> ids,
             string json)
         {

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace JohnsonControls.Metasys.BasicServices
+{
+    public class TraditionalClient
+    {
+
+        public Guid GetObjectIdentifier(string itemReference)
+        {
+            // Consider caching results since clients may not. If we add caching, then we could  consider
+            // taking itemReferences in ReadProperty and ReadPropertyMultiple. Until then we want to get clients
+            // used to using identifiers.
+            throw new NotImplementedException();
+        }
+
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// If the data type is not supported, then this should probably throw an exception. Or the ReadPropertyResult
+        /// could include an error code. Exception is probably simplest. Consider Excel app integration however. In those
+        /// cases adding error code field to ReadPropertyResult is better.
+        /// </remarks>
+        /// <param name="id"></param>
+        /// <param name="attributeName"></param>
+        /// <returns></returns>
+
+        /// <exception cref=""></exception>
+        /// which exceptions?
+        /// If it's communication issues with client then perhaps CommunicationException
+        /// If it's an HttpStatusCode that we are prepared for then make up some Exceptions:
+        /// Other options?
+        public ReadPropertyResult ReadProperty(Guid id, string attributeName)
+        {
+            // Call /objects/{id}/attributes/{attributeName}
+            // You won't have schema information but we only support numbers, strings, booleans and enums which comes back as strings
+            // Convert the response to appropriate result settings StringValue, NumericValue and ArrayValue 
+            throw new NotImplementedException();
+        }
+
+
+        public IEnumerable<ReadPropertyResult> ReadPropertyMultiple(IEnumerable<Guid> ids,
+            IEnumerable<string> attributeNames)
+        {
+            // Most efficient implementation would read each object (async, and then join)
+            // using /objects/{id}?includeSchema=true
+            
+            // As each object comes in, filter it down to the attributes requested
+            // For each attribute calculate the stringvalue and numeric value
+            
+            
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -72,7 +72,7 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             var response = client.Request($"objects/{id}/attributes/{attributeName}")
                 .GetJsonAsync<JToken>();
-            return new ReadPropertyResult(response.Result["item"][attributeName], attributeName);
+            return new ReadPropertyResult(id, response.Result["item"][attributeName], attributeName);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace JohnsonControls.Metasys.BasicServices
                     {
                         lock (results) 
                         {
-                            results.Add(new ReadPropertyResult(value, attributeName));
+                            results.Add(new ReadPropertyResult(id, value, attributeName));
                         }
                     }
                 }

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -11,9 +11,8 @@ namespace JohnsonControls.Metasys.BasicServices
     {
         private FlurlClient client;
 
-        /// <summary>Returns the object identifier (id) of the specified object.</summary>
         /// <summary>
-        /// 
+        /// Creates a new TraditionalClient.
         /// </summary>
         /// <remarks>
         /// Takes an optional CultureInfo which is useful for formatting numbers. If not specified,
@@ -26,8 +25,9 @@ namespace JohnsonControls.Metasys.BasicServices
             var culture = cultureInfo ?? CultureInfo.CurrentCulture;
         }
 
-        // Probably a boolean isn't good enough as it doesn't give a client any indication of what went wrong.
-        // Could return an Result structure that contains error information or nothing.
+        /// <summary>
+        /// Attempts to login to the given host.
+        /// </summary>
         public void TryLogin(string username, string password, string hostname, ApiVersion version = ApiVersion.V2)
         {
             client = new FlurlClient($"https://{hostname}/api/{version}");
@@ -38,7 +38,9 @@ namespace JohnsonControls.Metasys.BasicServices
             client.Headers.Add("Authorization", $"Bearer {accessToken}");
         }
 
-                /// <summary>Requests a new access token, must be called before current token expires.</summary>
+        /// <summary>
+        /// Requests a new access token before current token expires.
+        /// </summary>
         public void Refresh() {
             var response = client.Request("refreshToken")
                 .GetJsonAsync<JToken>();
@@ -48,6 +50,9 @@ namespace JohnsonControls.Metasys.BasicServices
             
         }        
         
+        /// <summary>
+        /// Returns the object identifier (id) of the specified object.
+        /// </summary>
         public Guid GetObjectIdentifier(string itemReference)
         {
             // Consider caching results since clients may not. If we add caching, then we could  consider
@@ -72,7 +77,6 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="id"></param>
         /// <param name="attributeName"></param>
         /// <returns></returns>
-
         /// <exception cref=""></exception>
         /// which exceptions?
         /// If it's communication issues with client then perhaps CommunicationException

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -12,6 +12,10 @@ namespace JohnsonControls.Metasys.BasicServices
 
         public TraditionalClient(string username, string password, string hostname, int apiVersion)
         {
+            if (apiVersion != 2) {
+                Console.Error.WriteLine("Unsupported API Version, using Version 2.");
+                apiVersion = 2;
+            }
             client = new FlurlClient($"https://{hostname}/api/v{apiVersion}");
             var response = client.Request("login")
                 .PostJsonAsync(new {username, password})

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -1,11 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace JohnsonControls.Metasys.BasicServices
 {
     public class TraditionalClient
     {
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Takes an optional CultureInfo which is useful for formatting numbers. If not specified,
+        /// the user's current culture is used.
+        /// </remarks>
+        /// <param name="cultureInfo"></param>
+        /// <exception cref="NotImplementedException"></exception>
+        public TraditionalClient(CultureInfo cultureInfo = null)
+        {
+            var culture = cultureInfo ?? CultureInfo.CurrentCulture;
+            throw new NotImplementedException();
+        }
+
+        // Probably a boolean isn't good enough as it doesn't give a client any indication of what went wrong.
+        // Could return an Result structure that contains error information or nothing.
+        public bool TryLogin(string username, string password, string hostname, ApiVersion version = ApiVersion.V2)
+        {
+            throw new NotImplementedException();
+        }
+        
+        
         public Guid GetObjectIdentifier(string itemReference)
         {
             // Consider caching results since clients may not. If we add caching, then we could  consider

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using Flurl;
 using Flurl.Http;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Linq;
 using System.Threading;
@@ -106,9 +107,22 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="id"></param>
         /// <param name="attributeName"></param>
         /// <param name="newValue"></param>
-        public void WriteProperty(Guid id, string attributeName, string newValue, string priority = null)
+        public void WriteProperty(Guid id, string attributeName, object newValue, string priority = null)
         {
-            throw new NotImplementedException();
+            string body = "{ item: { ";
+            if (priority != null) {
+                body += $"priority: \"{priority}\", ";
+            }
+            var item = JsonConvert.SerializeObject(newValue);
+            body += $"{attributeName}: {item} }} }}";
+            
+            try {
+                var json = JsonConvert.DeserializeObject(body);
+                var response = client.Request($"objects/{id}").PatchJsonAsync(json);
+                Console.WriteLine(response.Result.StatusCode);
+            } catch (Newtonsoft.Json.JsonReaderException e) {
+                Console.Error.WriteLine("Could not format request.");
+            }
         }
 
         /// <summary>

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -324,10 +324,29 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Get all available commands given the Guid of the object.
         /// </summary>
+        /// <param name="id"></param>
         /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
-        public IEnumerable<string> GetCommands(Guid id)
+        public IEnumerable<Command> GetCommands(Guid id)
         {
-            throw new NotImplementedException();
+            var token = client.Request(new Url("objects")
+                .AppendPathSegments(id, "commands"))
+                .GetJsonAsync<JToken>();
+            
+            List<Command> commands = new List<Command>();
+            if (token.Result.Type == JTokenType.Array) {
+                var array = token.Result as JArray;
+                if (array != null) {
+                    foreach (JObject command in array) {
+                        Command c = new Command(command);
+                        commands.Add(c);
+                    }
+                } else {
+                    var task = LogErrorAsync("Could not parse response data.");
+                }
+            } else {
+                var task = LogErrorAsync("Could not parse response data.");
+            }
+            return commands;
         }
 
         /// <summary>

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Flurl;
 using Flurl.Http;
 using Newtonsoft.Json.Linq;
 
@@ -17,7 +18,6 @@ namespace JohnsonControls.Metasys.BasicServices
                 .ReceiveJson<JToken>();
             var accessToken = response.Result["accessToken"];
             client.Headers.Add("Authorization", $"Bearer {accessToken}");
-            
         }
 
         ///<summary>Requests a new access token, must be called before current token expires.</summary>
@@ -37,16 +37,11 @@ namespace JohnsonControls.Metasys.BasicServices
             // taking itemReferences in ReadProperty and ReadPropertyMultiple. Until then we want to get clients
             // used to using identifiers.
 
-            //     string id = await client.Request("objectIdentifiers")
-            //         .SetSetQueryParams(new
-            //         {
-            //             fqr = itemReference
-            //         })
-            //         .GetJsonAsync();
+            var response = client.Request($"objectIdentifiers")
+                .SetQueryParam("fqr", itemReference)
+                .GetStringAsync();
 
-            //     return new Guid(id);
-
-            throw new NotImplementedException();
+            return new Guid(response.Result.Trim('"'));
         }
 
         

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -225,17 +225,11 @@ namespace JohnsonControls.Metasys.BasicServices
                     try
                     {
                         JToken value = task.Result.Item2["item"][attributeName];
-                        lock (results)
-                        {
-                            results.Add(new ReadPropertyResult(id, value, attributeName));
-                        }
+                        results.Add(new ReadPropertyResult(id, value, attributeName));
                     }
                     catch (System.NullReferenceException)
                     {
-                        lock (results)
-                        {
-                            results.Add(new ReadPropertyResult(id, null, attributeName));
-                        }
+                        results.Add(new ReadPropertyResult(id, null, attributeName));
                     }
                 }
             }

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -14,8 +14,6 @@ namespace JohnsonControls.Metasys.BasicServices
     {
         private FlurlClient client;
 
-        private const string clientUndefinedMessage = "Client undefined please login with TryLogin method.";
-
         /// <summary>
         /// Creates a new TraditionalClient.
         /// </summary>
@@ -48,6 +46,11 @@ namespace JohnsonControls.Metasys.BasicServices
         private async Task LogErrorAsync(String message)
         {
             await Console.Error.WriteLineAsync(message);
+        }
+
+        private void LogClientUndefinedError()
+        {
+            var task = LogErrorAsync("Client undefined please login with TryLogin method.");
         }
 
         /// <summary>
@@ -83,7 +86,7 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             if (client == null)
             {
-                Console.Error.WriteLineAsync(clientUndefinedMessage);
+                LogClientUndefinedError();
                 return;
             }
 
@@ -111,7 +114,7 @@ namespace JohnsonControls.Metasys.BasicServices
             Guid empty = new Guid(new Byte[16]);
             if (client == null)
             {
-                Console.Error.WriteLineAsync(clientUndefinedMessage);
+                LogClientUndefinedError();
                 return empty;
             }
 
@@ -141,8 +144,8 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             if (client == null)
             {
-                Console.Error.WriteLineAsync(clientUndefinedMessage);
-                return null;
+                LogClientUndefinedError();
+                return new ReadPropertyResult(id, null, attributeName);
             }
 
             var response = client.Request(new Url("objects")
@@ -160,7 +163,7 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             if (client == null)
             {
-                Console.Error.WriteLineAsync(clientUndefinedMessage);
+                LogClientUndefinedError();
                 return null;
             }
 
@@ -230,7 +233,7 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             if (client == null)
             {
-                Console.Error.WriteLineAsync(clientUndefinedMessage);
+                LogClientUndefinedError();
                 return;
             }
             Dictionary<string, object> pairs = new Dictionary<string, object>();
@@ -266,7 +269,7 @@ namespace JohnsonControls.Metasys.BasicServices
         {
             if (client == null)
             {
-                Console.Error.WriteLineAsync(clientUndefinedMessage);
+                LogClientUndefinedError();
                 return;
             }
 
@@ -328,22 +331,35 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
         public IEnumerable<Command> GetCommands(Guid id)
         {
+            if (client == null)
+            {
+                LogClientUndefinedError();
+                return null;
+            }
+
             var token = client.Request(new Url("objects")
                 .AppendPathSegments(id, "commands"))
                 .GetJsonAsync<JToken>();
-            
+
             List<Command> commands = new List<Command>();
-            if (token.Result.Type == JTokenType.Array) {
+            if (token.Result.Type == JTokenType.Array)
+            {
                 var array = token.Result as JArray;
-                if (array != null) {
-                    foreach (JObject command in array) {
+                if (array != null)
+                {
+                    foreach (JObject command in array)
+                    {
                         Command c = new Command(command);
                         commands.Add(c);
                     }
-                } else {
+                }
+                else
+                {
                     var task = LogErrorAsync("Could not parse response data.");
                 }
-            } else {
+            }
+            else
+            {
                 var task = LogErrorAsync("Could not parse response data.");
             }
             return commands;
@@ -358,6 +374,12 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="JsonSerializationException"></exception>
         public void SendCommand(Guid id, string command, IEnumerable<object> values = null)
         {
+            if (client == null)
+            {
+                LogClientUndefinedError();
+                return;
+            }
+
             if (values == null)
             {
                 SendCommandRequest(id, command, new string[0]);

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -99,5 +99,48 @@ namespace JohnsonControls.Metasys.BasicServices
             });
             return results;
         }
+
+        /// <summary>
+        /// Write a single attribute given the Guid of the object
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="attributeName"></param>
+        /// <param name="newValue"></param>
+        public void WriteProperty(Guid id, string attributeName, string newValue, string priority = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Write to all attributes given the Guids of the objects
+        /// </summary>
+        /// <remarks>
+        /// If a property needs the priority field the WriteProperty method should be used
+        /// </remarks>
+        /// <param name="ids"></param>
+        /// <param name="attributeValues">The (attribute, newValue) pairs</param>
+        public void WritePropertyMultiple(IEnumerable<Guid> ids, IEnumerable<(string, string)> attributeValues)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Get all available commands given the Guid of the object
+        /// </summary>
+        public IEnumerable<string> GetCommands(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Send a command to an object
+        /// </summary>
+        /// <param name="ids"></param>
+        /// <param name="command"></param>
+        /// <param name="titleValues">The (title, newValue) pairs</param>
+        public void SendCommand(Guid id, string command, IEnumerable<(string, string)> titleValues = null)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -16,6 +16,8 @@ namespace JohnsonControls.Metasys.BasicServices
 
         private string accessToken;
 
+        private DateTime tokenExpires;
+
         /// <summary>
         /// Creates a new TraditionalClient.
         /// </summary>
@@ -62,6 +64,9 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="System.NullReferenceException"></exception>
         public void TryLogin(string username, string password, string hostname, ApiVersion version = ApiVersion.V2)
         {
+            if (client != null) {
+                client.Dispose();
+            }
             client = new FlurlClient($"https://{hostname}"
                 .AppendPathSegments("api", version));
             var response = client.Request("login")
@@ -71,7 +76,9 @@ namespace JohnsonControls.Metasys.BasicServices
             try
             {
                 var accessToken = response.Result["accessToken"];
+                var expires = response.Result["expires"];
                 this.accessToken = $"Bearer {accessToken.Value<string>()}";
+                this.tokenExpires = expires.Value<DateTime>();
                 client.Headers.Add("Authorization", this.accessToken);
             }
             catch (System.NullReferenceException)
@@ -99,7 +106,9 @@ namespace JohnsonControls.Metasys.BasicServices
             try
             {
                 var accessToken = response.Result["accessToken"];
+                var expires = response.Result["expires"];
                 this.accessToken = $"Bearer {accessToken.Value<string>()}";
+                this.tokenExpires = expires.Value<DateTime>();
                 client.Headers.Remove("Authorization");
                 client.Headers.Add("Authorization", this.accessToken);
             }

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using Flurl;
 using Flurl.Http;
 using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Threading;
 
 namespace JohnsonControls.Metasys.BasicServices
 {
@@ -113,9 +116,26 @@ namespace JohnsonControls.Metasys.BasicServices
             
             // As each object comes in, filter it down to the attributes requested
             // For each attribute calculate the stringvalue and numeric value
-            
-            
-            throw new NotImplementedException();
+
+            List<ReadPropertyResult> results = new List<ReadPropertyResult>() { };
+            Parallel.ForEach(ids, (id) => {
+                var response = client.Request($"objects/{id}")
+                .GetJsonAsync<JToken>();
+                foreach (string attributeName in attributeNames) 
+                {
+                    JToken value = response.Result["item"][attributeName];
+                    // Potentially add support for reading an object like the ReadProperty method.
+                    // If supported the functionality should be considered for migration to the ReadPropertyResult class.
+                    if (value != null) 
+                    {
+                        lock (results) 
+                        {
+                            results.Add(new ReadPropertyResult(value));
+                        }
+                    }
+                }
+            });
+            return results;
         }
     }
 }

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -1,16 +1,51 @@
 ﻿using System;
 using System.Collections.Generic;
+using Flurl.Http;
+using Newtonsoft.Json.Linq;
 
 namespace JohnsonControls.Metasys.BasicServices
 {
     public class TraditionalClient
     {
+        private FlurlClient client;
 
+        public TraditionalClient(string username, string password, string hostname, int apiVersion)
+        {
+            client = new FlurlClient($"https://{hostname}/api/v{apiVersion}");
+            var response = client.Request("login")
+                .PostJsonAsync(new {username, password})
+                .ReceiveJson<JToken>();
+            var accessToken = response.Result["accessToken"];
+            client.Headers.Add("Authorization", $"Bearer {accessToken}");
+            
+        }
+
+        ///<summary>Requests a new access token, must be called before current token expires.</summary>
+        public void Refresh() {
+            var response = client.Request("refreshToken")
+                .GetJsonAsync<JToken>();
+            var accessToken = response.Result["accessToken"];
+            client.Headers.Remove("Authorization");
+            client.Headers.Add("Authorization", $"Bearer {accessToken}");
+            
+        }
+
+        ///<summary>Returns the object identifier (id) of the specified object.</summary>
         public Guid GetObjectIdentifier(string itemReference)
         {
             // Consider caching results since clients may not. If we add caching, then we could  consider
             // taking itemReferences in ReadProperty and ReadPropertyMultiple. Until then we want to get clients
             // used to using identifiers.
+
+            //     string id = await client.Request("objectIdentifiers")
+            //         .SetSetQueryParams(new
+            //         {
+            //             fqr = itemReference
+            //         })
+            //         .GetJsonAsync();
+
+            //     return new Guid(id);
+
             throw new NotImplementedException();
         }
 
@@ -37,6 +72,13 @@ namespace JohnsonControls.Metasys.BasicServices
             // Call /objects/{id}/attributes/{attributeName}
             // You won't have schema information but we only support numbers, strings, booleans and enums which comes back as strings
             // Convert the response to appropriate result settings StringValue, NumericValue and ArrayValue 
+            // using (client)
+            // {
+            //     JToken token = await client.Request($"objects/{id}/attributes/{attributeName}").GetJsonAsync<JToken>();
+            //     return new ReadPropertyResult(token.item[attributeName]);
+            // }
+
+            // return null;
             throw new NotImplementedException();
         }
 

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -52,6 +52,8 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Attempts to login to the given host.
         /// </summary>
+        /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
+        /// <exception cref="System.NullReferenceException"></exception>
         public void TryLogin(string username, string password, string hostname, ApiVersion version = ApiVersion.V2)
         {
             client = new FlurlClient($"https://{hostname}"
@@ -71,6 +73,8 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Requests a new access token before current token expires.
         /// </summary>
+        /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
+        /// <exception cref="System.NullReferenceException"></exception>
         public void Refresh() {
             if (client == null) {
                 Console.Error.WriteLineAsync(clientUndefinedMessage);
@@ -92,6 +96,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Returns the object identifier (id) of the specified object.
         /// </summary>
+        /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
         public Guid? GetObjectIdentifier(string itemReference)
         {
             if (client == null) {
@@ -122,11 +127,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="id"></param>
         /// <param name="attributeName"></param>
         /// <returns></returns>
-        /// <exception cref=""></exception>
-        /// which exceptions?
-        /// If it's communication issues with client then perhaps CommunicationException
-        /// If it's an HttpStatusCode that we are prepared for then make up some Exceptions:
-        /// Other options?
+        /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
         public ReadPropertyResult ReadProperty(Guid id, string attributeName)
         {
             if (client == null) {
@@ -195,6 +196,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Read entire object given the Guid of the object asynchronously.
         /// </summary>
+        /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
         private async Task<(Guid, JToken)> ReadObjectAsync(Guid id) 
         {
             var response = await client.Request(new Url("objects")
@@ -209,6 +211,8 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="id"></param>
         /// <param name="attributeName"></param>
         /// <param name="newValue"></param>
+        /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
+        /// <exception cref="JsonSerializationException"></exception>
         public void WriteProperty(Guid id, string attributeName, object newValue, string priority = null)
         {
             if (client == null) {
@@ -239,6 +243,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </summary>
         /// <param name="ids"></param>
         /// <param name="attributeValues">The (attribute, value) pairs</param>
+        /// <exception cref="JsonSerializationException"></exception>
         public void WritePropertyMultiple(IEnumerable<Guid> ids, IEnumerable<(string, object)> attributeValues, string priority = null)
         {
             if (client == null) {
@@ -284,6 +289,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Write many attribute values in the provided json given the Guid of the object asynchronously.
         /// </summary>
+        /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
         private async Task WritePropertyAsync(Guid id, string json) 
         {
             var response = await client.Request(new Url("objects")
@@ -294,6 +300,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Get all available commands given the Guid of the object
         /// </summary>
+        /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
         public IEnumerable<string> GetCommands(Guid id)
         {
             throw new NotImplementedException();
@@ -305,6 +312,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="ids"></param>
         /// <param name="command"></param>
         /// <param name="titleValues">The (title, newValue) pairs</param>
+        /// <exception cref="Flurl.Http.FlurlHttpException"></exception>
         public void SendCommand(Guid id, string command, IEnumerable<(string, string)> titleValues = null)
         {
             throw new NotImplementedException();

--- a/basic-services/TraditionalClient.cs
+++ b/basic-services/TraditionalClient.cs
@@ -67,14 +67,10 @@ namespace JohnsonControls.Metasys.BasicServices
             // Call /objects/{id}/attributes/{attributeName}
             // You won't have schema information but we only support numbers, strings, booleans and enums which comes back as strings
             // Convert the response to appropriate result settings StringValue, NumericValue and ArrayValue 
-            // using (client)
-            // {
-            //     JToken token = await client.Request($"objects/{id}/attributes/{attributeName}").GetJsonAsync<JToken>();
-            //     return new ReadPropertyResult(token.item[attributeName]);
-            // }
 
-            // return null;
-            throw new NotImplementedException();
+            var response = client.Request($"objects/{id}/attributes/{attributeName}")
+                .GetJsonAsync<JToken>();
+            return new ReadPropertyResult(response.Result["item"][attributeName]);
         }
 
 

--- a/basic-services/basic-services.csproj
+++ b/basic-services/basic-services.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>JohnsonControls.Metasys.BasicServices</RootNamespace>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/basic-services/basic-services.csproj
+++ b/basic-services/basic-services.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Flurl" Version="2.8.2" />
+    <PackageReference Include="Flurl.Http" Version="2.4.2" />
   </ItemGroup>
 
 </Project>

--- a/basic-services/basic-services.csproj
+++ b/basic-services/basic-services.csproj
@@ -10,4 +10,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\README.md">
+      <Link>README.md</Link>
+    </Content>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Implemented the following for Traditional Client:
* Refresh
* GetObjectIdentifier
* ReadPropertyResult
* ReadPropertyResultMultiple

Implemented ReadPropertyResult for the following types of JToken:
* Integer
* Float
* String
* Array
* Object
* (default for unsupported types)

Known issues:
* Documentation/comments needs work
* ReadObject in ReadPropertyResult line 135 could have better logic based on real data.